### PR TITLE
Temporary fix: add lr_adjuster attribute to trainer to fix errors in …

### DIFF
--- a/bayesflow/trainers.py
+++ b/bayesflow/trainers.py
@@ -152,6 +152,8 @@ class Trainer:
         self.replay_buffer = None
         self.optimizer = None
         self.default_lr = default_lr
+        # Currently unused attribute
+        self.lr_adjuster = None
 
         # Checkpoint and helper classes settings
         self.max_to_keep = max_to_keep


### PR DESCRIPTION
…saving.

Depending how this will be adapted in the future, removing all references to lr_adjuster might be the better option