### PR TITLE
Installation instructions

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -22,13 +22,13 @@ Thereafter, activate the conda environment via
    eval "$($CONDA_DIR/bin/conda shell.bash hook)"
 
 (Run ``conda init`` once to automatically load conda in interactive shells.)
-Having installed and activated conda, optionally a local environment can be created via
+Having installed and activated conda, optionally you can create a local environment via
 
 .. code-block:: bash
 
    conda create -y -n bf python=3.10
 
-and activated via
+and activate via
 
 .. code-block:: bash
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -10,15 +10,29 @@ e.g. (on Linux)
 
 .. code-block:: bash
 
-   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-   bash Miniconda3-latest-Linux-x86_64.sh
-   rm Miniconda3-latest-Linux-x86_64.sh
+   CONDA_DIR=$PWD/miniconda3
+   wget -O Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+   bash Miniconda3.sh -b -p $CONDA_DIR
+   rm Miniconda3.sh
 
+Thereafter, activate the conda environment via
+
+.. code-block:: bash
+
+   eval "$($CONDA_DIR/bin/conda shell.bash hook)"
+
+(Run ``conda init`` once to automatically load conda in interactive shells.)
 Having installed and activated conda, optionally a local environment can be created via
 
 .. code-block:: bash
 
-   conda create -y -n bayesflow python=3.10
+   conda create -y -n bf python=3.10
+
+and activated via
+
+.. code-block:: bash
+
+   conda activate bf
 
 Install from GitHub
 -------------------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,17 +12,20 @@ Install from GitHub
 Install BayesFlow from GitHub via
 
 .. code-block:: bash
+
    pip install git+https://github.com/stefanradev93/bayesflow
 
 
 If you want to work with the latest development version (which may however be unstable), instead use
 
 .. code-block:: bash
+
    pip install git+https://github.com/stefanradev93/bayesflow@Development
 
 If you need access to the source code, instead use
 
 .. code-block:: bash
+
    git clone git@github.com:stefanradev93/bayesflow.git
    cd bayesflow
    pip install -e .

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,6 +12,7 @@ e.g. (on Linux)
 
    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
    bash Miniconda3-latest-Linux-x86_64.sh
+   rm Miniconda3-latest-Linux-x86_64.sh
 
 Having installed and activated conda, optionally a local environment can be created via
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -5,6 +5,19 @@ Requirements
 ------------
 
 This package requires Python 3.9 or later.
+A simple installation is possible via `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_,
+e.g. (on Linux)
+
+.. code-block:: bash
+
+   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+   bash Miniconda3-latest-Linux-x86_64.sh
+
+Having installed and activated conda, optionally a local environment can be created via
+
+.. code-block:: bash
+
+   conda create -y -n bayesflow python=3.10
 
 Install from GitHub
 -------------------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,0 +1,28 @@
+Install
+=======
+
+Requirements
+------------
+
+This package requires Python 3.9 or later.
+
+Install from GitHub
+-------------------
+
+Install BayesFlow from GitHub via
+
+.. code-block:: bash
+   pip install git+https://github.com/stefanradev93/bayesflow
+
+
+If you want to work with the latest development version (which may however be unstable), instead use
+
+.. code-block:: bash
+   pip install git+https://github.com/stefanradev93/bayesflow@Development
+
+If you need access to the source code, instead use
+
+.. code-block:: bash
+   git clone git@github.com:stefanradev93/bayesflow.git
+   cd bayesflow
+   pip install -e .

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -43,7 +43,6 @@ Install BayesFlow from GitHub via
 
    pip install git+https://github.com/stefanradev93/bayesflow
 
-
 If you want to work with the latest development version (which may however be unstable), instead use
 
 .. code-block:: bash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ overview of neurally bootstrapped Bayesian inference.
 
 <img src="img/high_level_framework.png" width=80% height=80%>
 
+## Install
+
+See [INSTALL.rst](INSTALL.rst) for installation instructions.
+
 ## Getting Started: Parameter Estimation
 
 The core functionality of BayesFlow is amortized Bayesian posterior estimation, as described in our paper:


### PR DESCRIPTION
Added installation instructions in a standard INSTALL.rst file, also linked from README.md. Currently only installation via GitHub provided, PyPI could be added when applicable.

Solves #53 