### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     seaborn >= 0.11
     tqdm >= 4.65
     matplotlib >= 3.5
-    m2r2 >= 0.3
     tensorflow-macos >= 2.10; sys_platform == 'darwin' and platform_machine == 'arm64'
     tensorflow >= 2.10.1; sys_platform != 'darwin' or platform_machine != 'arm64'
     tensorflow_probability >= 0.17
@@ -58,7 +57,6 @@ docs =
     sphinx >= 5.1.0
     nbsphinx >= 0.8.9
     sphinx-rtd-theme >= 1.0.0
-    m2r2 >= 0.3
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Remove the m2r2 model from the dependencies because the installation introduced conflicts with the mistune module version