### PR TITLE
order doc methods by source

### DIFF
--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -52,6 +52,7 @@ autodoc_default_options = {
     "special-members": "__call__,__init__",
     "undoc-members": True,
     "exclude-members": "__weakref__",
+    "member-order": "bysource"
 }
 
 # Define shorthand for external links:


### PR DESCRIPTION
By default, `sphinx` orders methods alphabetically, but ordering by source is desirable in the case of this repository.