### PR TITLE
README - update minimal example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ def prior(D=2, mu=0., sigma=1.0):
 Then, we connect the `prior` with the `simulator` using a `GenerativeModel` wrapper:
 
 ```python
-generative_model = bf.simulation.GenerativeModel(prior, simulator)
+generative_model = bf.simulation.GenerativeModel(prior, simulator, simulator_is_batched=False)
 ```
 
 Next, we create our BayesFlow setup consisting of a summary and an inference network:


### PR DESCRIPTION
An outdated call to `bf.simulation.GenerativeModel` leads to a `ConfigurationError`. This PR updates the call to include the required `simulation_is_batched` argument.