### PR TITLE
Fix docstrings

### DIFF
--- a/bayesflow/amortizers.py
+++ b/bayesflow/amortizers.py
@@ -1316,6 +1316,100 @@ class AmortizedPointEstimator(tf.keras.Model):
             return estimates.numpy()
         return estimates
 
+    def bootstrap_sample(self, forward_dict, n_bootstrap, simulator, configurator, to_numpy=True, **kwargs):
+        """Obtain bootstrap samples with parametric bootstrap for all provided estimates.
+
+        Parameters
+        ----------
+        forward_dict: dict
+            Output of a ``GenerativeModel`` instance containing prior and simulator draws, as well as context variables.
+        n_bootstrap         : int
+            Number of bootstrap samples to draw for every estimate.
+        simulator           : bayesflow.simulation.Simulator
+            A data generator accepting parameter draws, optional context, and optional arguments as input
+            and returning observable data.
+        configurator        : callable
+            A callable object transforming and combining the outputs of the generative model into inputs for a BayesFlow
+            amortizer. Typically, this is the same callable as bayesflow.trainers.Trainer.configurator.
+        to_numpy            : bool, optional, default: True
+
+        Returns
+        -------
+        bootstrap_estimates : tf.Tensor or np.ndarray of shape (num_data_sets, n_bootstrap, num_params)
+            Estimated parameter values from parametric bootstrap samples.
+        """
+
+        # Obtain estimates
+        estimates = self.estimate(configurator(forward_dict), **kwargs)
+
+        # Prepare for bootstrap simulations based on estimates: Tile estimates
+        estimates_tiled = np.tile(estimates, (n_bootstrap,1))
+
+        # Prepare placeholder dictionary for simulation based on n_bootstrap datasets for every estimate
+        sim_dict = {
+            DEFAULT_KEYS["sim_data"]: None,
+            DEFAULT_KEYS["batchable_context"]: None,
+            DEFAULT_KEYS["non_batchable_context"]: None,
+        }
+
+        # Populate dictionary with batchable context from forward_dict or leave at None
+        if DEFAULT_KEYS["sim_batchable_context"] in forward_dict.keys() and forward_dict[DEFAULT_KEYS["sim_batchable_context"]] is not None:
+
+            sim_batchable_context = tf.constant(forward_dict[DEFAULT_KEYS["sim_batchable_context"]])
+
+            # If sim_batchable_context is a 1D tensor, i.e. single element per dataset, add an axis before tiling
+            if sim_batchable_context.ndim == 1:
+                sim_batchable_context_tiled = tf.tile(sim_batchable_context[:,None], (n_bootstrap, 1))
+            else:
+                sim_batchable_context_tiled = tf.tile(sim_batchable_context, (n_bootstrap, 1))
+
+            sim_dict[DEFAULT_KEYS["batchable_context"]] = sim_batchable_context_tiled
+
+        # Populate dictionary with non-batchable context from forward_dict or leave at None
+        if DEFAULT_KEYS["sim_non_batchable_context"] in forward_dict.keys() and forward_dict[DEFAULT_KEYS["sim_non_batchable_context"]] is not None:
+            sim_dict[DEFAULT_KEYS["non_batchable_context"]] = forward_dict[DEFAULT_KEYS["sim_non_batchable_context"]]
+
+        # Simulate data based on estimates and context, both tiled `n_bootstrap` times
+        if simulator.is_batched:
+            sim_dict = simulator._simulate_batched(estimates_tiled, sim_dict, **kwargs.pop("sim_args", {}))    # TODO: think again: for now intentionally left out *args compared to simulator.__call__(), bc could bring unintended behavior
+        else:
+            sim_dict = simulator._simulate_non_batched(estimates_tiled, sim_dict, **kwargs.pop("sim_args", {})) # TODO: test if sim_args are passed successfully
+
+        # To ensure proper configuration prior to estimation, we need to tile prior_batchable_context as well
+        forward_dict = forward_dict.copy()
+        if DEFAULT_KEYS["prior_batchable_context"] in forward_dict.keys() and forward_dict[DEFAULT_KEYS["prior_batchable_context"]] is not None:
+
+            prior_batchable_context = tf.constant(forward_dict[DEFAULT_KEYS["prior_batchable_context"]])
+
+            # If prior_batchable_context is a 1D tensor, i.e. single element per dataset, add an axis before tiling
+            if prior_batchable_context.ndim == 1:
+                prior_batchable_context_tiled = tf.tile(prior_batchable_context[:,None], (n_bootstrap, 1))
+            else:
+                prior_batchable_context_tiled = tf.tile(prior_batchable_context, (n_bootstrap, 1))
+
+            forward_dict[DEFAULT_KEYS["prior_batchable_context"]] = prior_batchable_context_tiled
+
+        # The estimates are now used as parameters, or prior draws in the context of the forward process
+        forward_dict[DEFAULT_KEYS["prior_draws"]] = estimates_tiled
+
+        # Include bootstrap simulations; non_batchable_context remains unchanged
+        forward_dict[DEFAULT_KEYS["sim_batchable_context"]] = sim_dict[DEFAULT_KEYS["batchable_context"]]
+        forward_dict[DEFAULT_KEYS["sim_data"]] = sim_dict[DEFAULT_KEYS["sim_data"]]
+
+        # Obtain bootstrap estimates from the new forward_dict
+        configured_dict = configurator(forward_dict)
+        bootstrap_estimates_tiled = self.estimate(configured_dict)
+
+        # Reshape and reorder to (num_data_sets, n_bootstrap, num_params)
+        bootstrap_estimates = tf.transpose(
+            tf.reshape(bootstrap_estimates_tiled, (n_bootstrap, estimates.shape[0], estimates.shape[1])),
+            perm=[1,0,2]
+        )
+
+        if to_numpy:
+            return bootstrap_estimates.numpy()
+        return bootstrap_estimates
+
     def compute_loss(self, input_dict, **kwargs):
         """Computes the loss of the posterior amortizer given an input dictionary, which will
         typically be the output of a Bayesian ``GenerativeModel`` instance.

--- a/bayesflow/amortizers.py
+++ b/bayesflow/amortizers.py
@@ -1259,7 +1259,6 @@ class AmortizedPointEstimator(tf.keras.Model):
         ----------
         input_dict     : dict
             Input dictionary containing the following mandatory keys, if ``DEFAULT_KEYS`` unchanged:
-            ``parameters``         - the latent model parameters over which a condition density is learned
             ``summary_conditions`` - the conditioning variables (including data) that are first passed through a summary network
             ``direct_conditions``  - the conditioning variables that the directly passed to the inference network
         return_summary : bool, optional, default: False

--- a/bayesflow/configuration.py
+++ b/bayesflow/configuration.py
@@ -43,7 +43,7 @@ class DefaultJointConfigurator:
 
 
 class DefaultLikelihoodConfigurator:
-    """Fallback class for a generic configrator for amortized likelihood approximation."""
+    """Fallback class for a generic configurator for amortized likelihood approximation."""
 
     def __init__(self, default_float_type=np.float32):
         self.default_float_type = default_float_type
@@ -214,7 +214,7 @@ class DefaultCombiner:
 
 
 class DefaultPosteriorConfigurator:
-    """Fallback class for a generic configrator for amortized posterior approximation."""
+    """Fallback class for a generic configurator for amortized posterior approximation."""
 
     def __init__(self, default_float_type=np.float32):
         self.default_float_type = default_float_type

--- a/bayesflow/simulation.py
+++ b/bayesflow/simulation.py
@@ -43,7 +43,7 @@ class ContextGenerator:
     The interface distinguishes between two types of context: batchable and non-batchable.
 
     - Batchable context variables differ for each simulation in each training batch
-    - Non-batchable context varibales stay the same for each simulation in a batch, but differ across batches
+    - Non-batchable context variables stay the same for each simulation in a batch, but differ across batches
 
     Examples for batchable context variables include experimental design variables, design matrices, etc.
     Examples for non-batchable context variables include the number of observations in an experiment, positional
@@ -190,10 +190,10 @@ class Prior:
         Parameters
         ----------
         batch_prior_fun     : callable
-            A function (callbale object) with optional control arguments responsible for generating batches
+            A function (callable object) with optional control arguments responsible for generating batches
             of per-simulation parameters.
         prior_fun           : callable
-            A function (callbale object) with optional control arguments responsible for generating
+            A function (callable object) with optional control arguments responsible for generating
             per-simulation parameters.
         context generator   : callable, optional, (default None, recommended instance of ContextGenerator)
             An optional function (ideally an instance of ContextGenerator) for generating prior context variables.
@@ -226,7 +226,7 @@ class Prior:
 
         Returns
         -------
-        out_dict - a dictionary with the quantities generated from the prior + context funcitons.
+        out_dict - a dictionary with the quantities generated from the prior + context functions.
         """
 
         # Prepare placeholder output dictionary
@@ -315,7 +315,7 @@ class Prior:
         return out_dict
 
     def plot_prior2d(self, **kwargs):
-        """Generates a 2D plot representing bivariate prior ditributions. Uses the function
+        """Generates a 2D plot representing bivariate prior distributions. Uses the function
         ``bayesflow.diagnostics.plot_prior2d()`` internally for generating the plot.
 
         Parameters
@@ -392,12 +392,12 @@ class TwoLevelPrior:
         Parameters
         ----------
         hyper_prior_fun         : callable
-            A function (callbale object) which generates random draws from a hyperprior (unconditional)
+            A function (callable object) which generates random draws from a hyperprior (unconditional)
         local_prior_fun         : callable
             A function (callable object) which generates random draws from a conditional prior
             given hyperparameters sampled from the hyperprior and optional context (e.g., variable number of groups)
         shared_prior_fun        : callable or None, optional, default: None
-            A function (callable object) which generates random draws from an uncondtional prior.
+            A function (callable object) which generates random draws from an unconditional prior.
             Represents optional shared parameters.
         local_context_generator : callable or None, optional, default: None
             An optional function (ideally an instance of ``ContextGenerator``) for generating control variables
@@ -535,10 +535,10 @@ class Simulator:
         Parameters
         ----------
         batch_simulator_fun  : callable
-            A function (callbale object) with optional control arguments responsible for generating a batch of simulations
+            A function (callable object) with optional control arguments responsible for generating a batch of simulations
             given a batch of parameters and optional context variables.
         simulator_fun       : callable
-            A function (callable object) with optional control arguments responsible for generating a simulaiton given
+            A function (callable object) with optional control arguments responsible for generating a simulation given
             a single parameter vector and optional variables.
         context_generator   : callable (default None, recommended instance of ContextGenerator)
             An optional function (ideally an instance of ``ContextGenerator``) for generating prior context variables.
@@ -723,14 +723,14 @@ class GenerativeModel:
             prior knowledge about plausible parameter ranges
         simulator            : callable or bayesflow.simulation.Simulator
             A function accepting parameter draws, optional context, and optional arguments as input
-            and returning obseravble data
+            and returning observable data
         skip_test            : bool, optional, default: False
             If True, a forward inference pass will be performed.
         prior_is_batched     : bool, optional, default: False
             Only relevant and mandatory if providing a custom prior without the ``Prior`` wrapper.
         simulator_is_batched : bool or None, optional, default: None
             Only relevant and mandatory if providing a custom simulator without he ``Simulator`` wrapper.
-        name                 : str (default - "anonoymous")
+        name                 : str (default - "anonymous")
             An optional name for the generative model. If kept default (None), 'anonymous' is set as name.
 
         Notes


### PR DESCRIPTION
Tiny typos mostly, but one instance where docstring was not accurate for `AmortizedPointEstimator.call()`.