### PR TITLE
Improve requirements

### DIFF
--- a/env_dev.yml
+++ b/env_dev.yml
@@ -1,0 +1,27 @@
+# "dev" conda envs are to be used by devs in setting their local environments
+name: bf-dev
+channels:
+- conda-forge
+- defaults
+dependencies:
+- aesara
+- black
+- flake8>=6.1.0
+- ipywidgets
+- isort
+- jupyter
+- matplotlib
+- minikanren
+- mypy>=1.5.1
+- nbqa
+- pandas
+- pip
+- pytest>=7.2.0
+- pytest-xdist>=3.5.0
+- pytest-cov>=4.1.0
+- scikit-learn
+- seaborn
+- tensorflow<2.16,>=2.10.1
+- tensorflow-probability<0.24,>=0.17
+- tox>=4.10.0
+- watermark

--- a/env_dev.yml
+++ b/env_dev.yml
@@ -8,6 +8,7 @@ dependencies:
 - flake8>=6.1.0
 - ipywidgets
 - jupyter
+- jupytext
 - matplotlib
 - minikanren
 - mypy>=1.5.1

--- a/env_dev.yml
+++ b/env_dev.yml
@@ -5,15 +5,12 @@ channels:
 - defaults
 dependencies:
 - aesara
-- black
 - flake8>=6.1.0
 - ipywidgets
-- isort
 - jupyter
 - matplotlib
 - minikanren
 - mypy>=1.5.1
-- nbqa
 - pandas
 - pip
 - pytest>=7.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,7 @@ target-version = ["py310", "py311"]
 profile = "black"
 line_length = 120
 multi_line_output = 3
+
+[tool.jupytext.formats]
+"examples/" = "ipynb"
+"scripts/" = "md"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,10 @@
 flake8>=6.1.0
-tox>=4.10.0
+ipywidgets
+jupyter
+mypy>=1.5.1
 pytest>=7.2.0
 pytest-xdist>=3.5.0
 pytest-cov>=4.1.0
-myp>=1.5.1
+tensorflow<2.16,>=2.10.1
+tensorflow-probability<0.24,>=0.17
+tox>=4.10.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,9 +2,13 @@ flake8>=6.1.0
 ipywidgets
 jupyter
 mypy>=1.5.1
+pandas
 pytest>=7.2.0
 pytest-xdist>=3.5.0
 pytest-cov>=4.1.0
+scikit-learn
+seaborn
 tensorflow<2.16,>=2.10.1
 tensorflow-probability<0.24,>=0.17
 tox>=4.10.0
+watermark


### PR DESCRIPTION
- Added main requirements explicitly to `requirements_dev.txt`
- Created a mirror `env_dev.yml`, to enable [mamba](https://mamba.readthedocs.io/en/latest/index.html) installation for developers
- Added [jupytext](https://jupytext.readthedocs.io/en/latest/index.html) for easier review and conflict resolution of Jupyter NBs
- Fixed typo in `requirements-dev.txt`: myp --> mypy

Concretely, that means developers can install BayesFlow in at least 2 ways:
 - pip:
```python
mamba create --name bf-dev python=3.11
mamba activate bf-dev
pip install -e .
pip install -r requirements_dev.txt
```

- Full mamba (which I usually prefer if any compilers are needed):
```python
mamba env create -f env_dev.yml
mamba activate bf-dev
python setup.py develop
```

Ready for review 🍾 