### PR TITLE
Strict enforcement of inductive bias in quantile estimation

### DIFF
--- a/bayesflow/helper_networks.py
+++ b/bayesflow/helper_networks.py
@@ -709,8 +709,8 @@ class QuantileActivation(tf.keras.layers.Layer):
         # Apply exponential activation and cumulate to ensure ordered quantiles
         below = tf.exp(below_inputs)
         above = tf.exp(above_inputs)
-        below = anchor_input - tf.cumsum(below_inputs, axis=1)
-        above = anchor_input + tf.cumsum(above_inputs, axis=1)
+        below = anchor_input - tf.cumsum(below, axis=1)[:, ::-1, :]
+        above = anchor_input + tf.cumsum(above, axis=1)
 
         # Concatenate and reshape back
         x = tf.concat([below, anchor_input, above], axis=1)

--- a/bayesflow/losses.py
+++ b/bayesflow/losses.py
@@ -230,7 +230,6 @@ def quantile_loss(y_pred, y_true, quantile_levels=[0.05, 0.95]):
     tau = tf.constant(quantile_levels, dtype=tf.float32)
     n_quantiles = tau.shape[0]
 
-    # If requested, reshape to separate n_quantiles from n_params
     assert (
         y_pred.shape[-2] == n_quantiles
     ), "Second-to-last dimension of network output should contain quantiles for different quantile levels! The dimension does not match with the specified quantile levels."


### PR DESCRIPTION
This fixes a bug that had previously lead to the activation function for quantile estimation not enforcing the inductive bias correctly.