### PR TITLE
Loss progress tests

### DIFF
--- a/bayesflow/simulators/__init__.py
+++ b/bayesflow/simulators/__init__.py
@@ -1,2 +1,3 @@
 from .sequential_simulator import SequentialSimulator
 from .two_moons_simulator import TwoMoonsSimulator
+from .normal_simulator import NormalSimulator

--- a/bayesflow/simulators/normal_simulator.py
+++ b/bayesflow/simulators/normal_simulator.py
@@ -1,0 +1,20 @@
+import keras
+
+from .simulator import Simulator
+from ..types import Shape, Tensor
+
+
+class NormalSimulator(Simulator):
+    """TODO: Docstring"""
+
+    def sample(self, batch_shape: Shape, num_observations: int = 32) -> dict[str, Tensor]:
+        mean = keras.random.normal(batch_shape + (2,), 0.0, 0.1)
+        mean = keras.ops.repeat(mean[:, None], num_observations, 1)
+
+        std = keras.ops.exp(keras.random.normal(batch_shape + (2,), 0.0, 0.1))
+        std = keras.ops.repeat(std[:, None], num_observations, 1)
+
+        noise = keras.random.normal(batch_shape + (num_observations, 2))
+
+        x = mean + std * noise
+        return dict(mean=mean, std=std, x=x)

--- a/tests/test_approximators/test_fit.py
+++ b/tests/test_approximators/test_fit.py
@@ -17,29 +17,27 @@ def test_fit(amortizer, dataset):
     assert amortizer.losses is not None
 
 
-def test_loss_progress(approximator, dataset):
-    # TODO: Add assertion for validation history (this will make string searching less hacky)
+def test_loss_progress(approximator, train_dataset, validation_dataset):
     approximator.compile(optimizer="AdamW")
     num_epochs = 3
-    num_batches = len(dataset)
 
     # Capture ostream and train model
     ostream = io.StringIO()
     with redirect_stdout(ostream):
-        history = approximator.fit(dataset, epochs=num_epochs).history
+        history = approximator.fit(train_dataset, validation_data=validation_dataset, epochs=num_epochs).history
     output = ostream.getvalue()
     ostream.close()
 
-    losses = [line for line in output.splitlines() if "loss" in line]
-    assert len(losses) == (num_batches + 1) * num_epochs
+    loss_output = [line for line in output.splitlines() if "loss" in line]
 
-    # Assert losses are not NaN and epoch summaries match history
+    # Test losses are not NaN and that epoch summaries match loss histories
     epoch = 0
-    for i, line in enumerate(losses):
-        loss = float(line.split()[-1])
-        assert not np.isnan(loss)
-
-        if i % (num_batches + 1) == num_batches:
-            print(f"History: {round(history["loss"][epoch], 4)} | Captured: {loss}")
-            assert round(history["loss"][epoch], 4) == loss
+    for loss_stats in loss_output:
+        content = loss_stats.split()
+        if "val_loss" in loss_stats:
+            assert float(content[-4]) == round(history["loss"][epoch], 4)
+            assert float(content[-1]) == round(history["val_loss"][epoch], 4)
             epoch += 1
+            continue
+
+        assert not np.isnan(float(content[-1]))

--- a/tests/test_approximators/test_fit.py
+++ b/tests/test_approximators/test_fit.py
@@ -1,4 +1,7 @@
 import pytest
+import io
+import numpy as np
+from contextlib import redirect_stdout
 
 
 @pytest.mark.skip(reason="not implemented")
@@ -12,3 +15,31 @@ def test_fit(amortizer, dataset):
     amortizer.fit(dataset)
 
     assert amortizer.losses is not None
+
+
+def test_loss_progress(approximator, dataset):
+    # TODO: Add assertion for validation history (this will make string searching less hacky)
+    approximator.compile(optimizer="AdamW")
+    num_epochs = 3
+    num_batches = len(dataset)
+
+    # Capture ostream and train model
+    ostream = io.StringIO()
+    with redirect_stdout(ostream):
+        history = approximator.fit(dataset, epochs=num_epochs).history
+    output = ostream.getvalue()
+    ostream.close()
+
+    losses = [line for line in output.splitlines() if "loss" in line]
+    assert len(losses) == (num_batches + 1) * num_epochs
+
+    # Assert losses are not NaN and epoch summaries match history
+    epoch = 0
+    for i, line in enumerate(losses):
+        loss = float(line.split()[-1])
+        assert not np.isnan(loss)
+
+        if i % (num_batches + 1) == num_batches:
+            print(f"History: {round(history["loss"][epoch], 4)} | Captured: {loss}")
+            assert round(history["loss"][epoch], 4) == loss
+            epoch += 1

--- a/tests/test_approximators/test_fit.py
+++ b/tests/test_approximators/test_fit.py
@@ -28,7 +28,7 @@ def test_loss_progress(approximator, train_dataset, validation_dataset):
     output = ostream.getvalue()
     ostream.close()
 
-    loss_output = [line for line in output.splitlines() if "loss" in line]
+    loss_output = [line.replace("\x08", "") for line in output.splitlines() if "loss" in line]
 
     # Test losses are not NaN and that epoch summaries match loss histories
     epoch = 0


### PR DESCRIPTION
Implements changes for Jira BF-28:
Added tests to inspect loss progress and loss on the progress bar

Changes:
`test_approximators/test_fit.py`
- Added `test_loss_progress` to monitor the training loss progression in stdout. This is done by checking that the loss reported for each batch is not NaN, and ensuring that the captured epoch summary loss and validation loss match the model's history  

`test_approximators/conftest.py`
- Updated `inference_network` fixture to use `CouplingFlow`
- Added inference variables and conditions to `approximator` fixture
- Removed `dataset` fixture
- Added `simulator` fixture to use new `NormalSimulator`
- Added `train_dataset` fixture
- Added `validation_dataset` fixture

`simulators/normal_simulator.py`
- Added `NormalSimulator` with sampling for fit tests

`simulators/__init__.py`
- Added import for `NormalSimulator`