### PR TITLE
Benchmarks refactor

### DIFF
--- a/bayesflow/benchmarks/benchmark.py
+++ b/bayesflow/benchmarks/benchmark.py
@@ -11,6 +11,7 @@ class Benchmark:
         - two_moons
         - sir
         - lotka_volterra
+        - inverse_kinematics
 
         # TODO
         """

--- a/bayesflow/benchmarks/benchmark.py
+++ b/bayesflow/benchmarks/benchmark.py
@@ -6,7 +6,13 @@ from bayesflow.utils import batched_call
 
 class Benchmark:
     def __init__(self, name: str, **kwargs):
-        """#TODO"""
+        """
+        Currently supported benchmarks:
+        - two_moons
+        - sir
+
+        # TODO
+        """
 
         self.name = name
         self.module = self.get_module(name)

--- a/bayesflow/benchmarks/benchmark.py
+++ b/bayesflow/benchmarks/benchmark.py
@@ -10,6 +10,7 @@ class Benchmark:
         Currently supported benchmarks:
         - two_moons
         - sir
+        - lotka_volterra
 
         # TODO
         """

--- a/bayesflow/benchmarks/benchmark.py
+++ b/bayesflow/benchmarks/benchmark.py
@@ -8,12 +8,19 @@ class Benchmark:
     def __init__(self, name: str, **kwargs):
         """
         Currently supported benchmarks:
-        - two_moons
-        - sir
-        - lotka_volterra
+        - bernoulli_glm
+        - bernoulli_glm_raw
+        - gaussian_linear
+        - gaussian_linear_uniform
+        - gaussian_mixture
         - inverse_kinematics
+        - lotka_volterra
+        - sir
+        - slcp
+        - slcp_distractors
+        - two_moons
 
-        # TODO
+        TODO: Docs
         """
 
         self.name = name

--- a/bayesflow/benchmarks/bernoulli_glm.py
+++ b/bayesflow/benchmarks/bernoulli_glm.py
@@ -1,0 +1,91 @@
+import numpy as np
+from scipy.special import expit
+
+
+# Global covariance matrix computed once for efficiency
+F = np.zeros((9, 9))
+for i in range(9):
+    F[i, i] = 1 + np.sqrt(i / 9)
+    if i >= 1:
+        F[i, i - 1] = -2
+    if i >= 2:
+        F[i, i - 2] = 1
+Cov = np.linalg.inv(F.T @ F)
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(rng: np.random.Generator = None):
+    """Generates a random draw from the custom prior over the 10
+    Bernoulli GLM parameters (1 intercept and 9 weights). Uses a
+    global covariance matrix `Cov` for the multivariate Gaussian prior
+    over the model weights, which is pre-computed for efficiency.
+
+    Parameters
+    ----------
+    rng   : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    params : np.ndarray of shape (10,)
+        A single draw from the prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    beta = rng.normal(0, 2)
+    f = rng.multivariate_normal(np.zeros(9), Cov)
+    return np.append(beta, f)
+
+
+def observation_model(params: np.ndarray, T: int = 100, scale_by_T: bool = True, rng: np.random.Generator = None):
+    """Simulates data from the custom Bernoulli GLM likelihood, see
+    https://arxiv.org/pdf/2101.04653.pdf, Task T.5
+
+    Important: `scale_sum` should be set to False if the simulator is used
+    with variable `T` during training, otherwise the information of `T` will
+    be lost.
+
+    Parameters
+    ----------
+    params     : np.ndarray of shape (10,)
+        The vector of model parameters (`params[0]` is intercept, `params[i], i > 0` are weights).
+    T          : int, optional, default: 100
+        The simulated duration of the task (eq. the number of Bernoulli draws).
+    scale_by_T : bool, optional, default: True
+        A flag indicating whether to scale the summayr statistics by T.
+    rng        : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (10,)
+        The vector of sufficient summary statistics of the data.
+    """
+
+    # Use default RNG, if None provided
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Unpack parameters
+    beta, f = params[0], params[1:]
+
+    # Generate design matrix
+    V = rng.normal(size=(9, T))
+
+    # Draw from Bernoulli GLM
+    z = rng.binomial(n=1, p=expit(V.T @ f + beta))
+
+    # Compute and return (scaled) sufficient summary statistics
+    x1 = np.sum(z)
+    x_rest = V @ z
+    x = np.append(x1, x_rest)
+    if scale_by_T:
+        x /= T
+    return x

--- a/bayesflow/benchmarks/bernoulli_glm_raw.py
+++ b/bayesflow/benchmarks/bernoulli_glm_raw.py
@@ -1,0 +1,81 @@
+import numpy as np
+from scipy.special import expit
+
+
+# Global covariance matrix computed once for efficiency
+F = np.zeros((9, 9))
+for i in range(9):
+    F[i, i] = 1 + np.sqrt(i / 9)
+    if i >= 1:
+        F[i, i - 1] = -2
+    if i >= 2:
+        F[i, i - 2] = 1
+Cov = np.linalg.inv(F.T @ F)
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(rng: np.random.Generator = None):
+    """Generates a random draw from the custom prior over the 10
+    Bernoulli GLM parameters (1 intercept and 9 weights). Uses a
+    global covariance matrix `Cov` for the multivariate Gaussian prior
+    over the model weights, which is pre-computed for efficiency.
+
+    Parameters
+    ----------
+    rng   : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    params : np.ndarray of shape (10,)
+        A single draw from the prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    beta = rng.normal(0, 2)
+    f = rng.multivariate_normal(np.zeros(9), Cov)
+    return np.append(beta, f)
+
+
+def observation_model(params: np.ndarray, T: int = 100, rng: np.random.Generator = None):
+    """Simulates data from the custom Bernoulli GLM likelihood, see:
+    https://arxiv.org/pdf/2101.04653.pdf, Task T.6
+
+    Returns the raw Bernoulli data.
+
+    Parameters
+    ----------
+    params : np.ndarray of shape (10,)
+        The vector of model parameters (`params[0]` is intercept, `params[i], i > 0` are weights)
+    T      : int, optional, default: 100
+        The simulated duration of the task (eq. the number of Bernoulli draws).
+    rng    : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (T, 10)
+        The full simulated set of Bernoulli draws and design matrix.
+        Should be configured with an additional trailing dimension if the data is (properly) to be treated as a set.
+    """
+
+    # Use default RNG, if None provided
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Unpack parameters
+    beta, f = params[0], params[1:]
+
+    # Generate design matrix
+    V = rng.normal(size=(9, T))
+
+    # Draw from Bernoulli GLM and return
+    z = rng.binomial(n=1, p=expit(V.T @ f + beta))
+    return np.c_[np.expand_dims(z, axis=-1), V.T]

--- a/bayesflow/benchmarks/gaussian_linear.py
+++ b/bayesflow/benchmarks/gaussian_linear.py
@@ -37,7 +37,7 @@ def observation_model(params: np.ndarray, n_obs: int = None, scale: float = 0.1,
     """Generates batched draws from a D-dimenional Gaussian distributions given a batch of
     location (mean) parameters of D dimensions. Assumes a spherical convariance matrix given
     by scale * I_D.
-    
+
     See Task T.1 from the paper https://arxiv.org/pdf/2101.04653.pdf
     NOTE: The paper description uses a variance of 0.1 for the prior and likelihood
     but the implementation uses scale = 0.1 Our implmenetation uses a default scale

--- a/bayesflow/benchmarks/gaussian_linear.py
+++ b/bayesflow/benchmarks/gaussian_linear.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(D: int = 10, scale: float = 0.1, rng: np.random.Generator = None):
+    """Generates a random draw from a D-dimensional Gaussian prior distribution with a
+    spherical scale matrix given by sigma * I_D. Represents the location vector of
+    a (conjugate) Gaussian likelihood.
+
+    Parameters
+    ----------
+    D     : int, optional, default : 10
+        The dimensionality of the Gaussian prior distribution.
+    scale : float, optional, default : 0.1
+        The scale of the Gaussian prior.
+    rng   : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    params : np.ndarray of shape (D, )
+        A single draw from the D-dimensional Gaussian prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    return scale * rng.normal(size=D)
+
+
+def observation_model(params: np.ndarray, n_obs: int = None, scale: float = 0.1, rng: np.random.Generator = None):
+    """Generates batched draws from a D-dimenional Gaussian distributions given a batch of
+    location (mean) parameters of D dimensions. Assumes a spherical convariance matrix given
+    by scale * I_D.
+    
+    See Task T.1 from the paper https://arxiv.org/pdf/2101.04653.pdf
+    NOTE: The paper description uses a variance of 0.1 for the prior and likelihood
+    but the implementation uses scale = 0.1 Our implmenetation uses a default scale
+    of 0.1 for consistency with the implementation.
+
+    Parameters
+    ----------
+    params : np.ndarray of shape (params, D)
+        The location parameters of the Gaussian likelihood.
+    n_obs  : int or None, optional, default: None
+        The number of observations to draw from the likelihood given the location
+        parameter `params`. If `n obs is None`, a single draw is produced.
+    scale  : float, optional, default : 0.1
+        The scale of the Gaussian likelihood.
+    rng    : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (params.shape[0], params.shape[1]) if n_obs is None,
+        else np.ndarray of shape (params.shape[0], n_obs, params.shape[1])
+        A single draw or a sample from a batch of Gaussians.
+    """
+
+    # Use default RNG, if None provided
+    if rng is None:
+        rng = np.random.default_rng()
+    # Generate prior predictive samples, possibly a single if n_obs is None
+    if n_obs is None:
+        return rng.normal(loc=params, scale=scale)
+    x = rng.normal(loc=params, scale=scale, size=(n_obs, params.shape[0], params.shape[1]))
+    return np.transpose(x, (1, 0, 2))

--- a/bayesflow/benchmarks/gaussian_linear_uniform.py
+++ b/bayesflow/benchmarks/gaussian_linear_uniform.py
@@ -39,12 +39,12 @@ def observation_model(params: np.ndarray, n_obs: int = None, scale: float = 0.1,
     """Generates batched draws from a D-dimenional Gaussian distributions given a batch of
     location (mean) parameters of D dimensions. Assumes a spherical convariance matrix given
     by scale * I_D.
-    
+
     See Task T.2 from the paper https://arxiv.org/pdf/2101.04653.pdf
     NOTE: The paper description uses a variance of 0.1 for likelihood function
     but the implementation uses scale = 0.1 Our implmenetation uses a default scale
     of 0.1 for consistency with the implementation.
-    
+
     Parameters
     ----------
     params : np.ndarray of shape (params, D)

--- a/bayesflow/benchmarks/gaussian_linear_uniform.py
+++ b/bayesflow/benchmarks/gaussian_linear_uniform.py
@@ -1,0 +1,74 @@
+import numpy as np
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(D: int = 10, lower_bound: float = -1.0, upper_bound: float = 1.0, rng: np.random.Generator = None):
+    """Generates a random draw from a D-dimensional uniform prior bounded between
+    `lower_bound` and `upper_bound` which represents the location vector of
+    a (conjugate) Gaussian likelihood.
+
+    Parameters
+    ----------
+    D           : int, optional, default : 10
+        The dimensionality of the Gaussian prior.
+    lower_bound : float, optional, default : -1.
+        The lower bound of the uniform prior.
+    upper_bound : float, optional, default : 1.
+        The upper bound of the uniform prior.
+    rng         : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    params : np.ndarray of shape (D, )
+        A single draw from the D-dimensional uniform prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    return rng.uniform(low=lower_bound, high=upper_bound, size=D)
+
+
+def observation_model(params: np.ndarray, n_obs: int = None, scale: float = 0.1, rng: np.random.Generator = None):
+    """Generates batched draws from a D-dimenional Gaussian distributions given a batch of
+    location (mean) parameters of D dimensions. Assumes a spherical convariance matrix given
+    by scale * I_D.
+    
+    See Task T.2 from the paper https://arxiv.org/pdf/2101.04653.pdf
+    NOTE: The paper description uses a variance of 0.1 for likelihood function
+    but the implementation uses scale = 0.1 Our implmenetation uses a default scale
+    of 0.1 for consistency with the implementation.
+    
+    Parameters
+    ----------
+    params : np.ndarray of shape (params, D)
+        The location parameters of the Gaussian likelihood.
+    n_obs  : int or None, optional, default: None
+        The number of observations to draw from the likelihood given the location
+        parameter `params`. If None, a single draw is produced.
+    scale  : float, optional, default : 0.1
+        The scale of the Gaussian likelihood.
+    rng    : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (params.shape[0], params.shape[1]) if n_obs is None,
+        else np.ndarray of shape (params.shape[0], n_obs, params.shape[1])
+        A single draw or a sample from a batch of Gaussians.
+    """
+
+    # Use default RNG, if None provided
+    if rng is None:
+        rng = np.random.default_rng()
+    # Generate prior predictive samples, possibly a single if n_obs is None
+    if n_obs is None:
+        return rng.normal(loc=params, scale=scale)
+    x = rng.normal(loc=params, scale=scale, size=(n_obs, params.shape[0], params.shape[1]))
+    return np.transpose(x, (1, 0, 2))

--- a/bayesflow/benchmarks/gaussian_mixture.py
+++ b/bayesflow/benchmarks/gaussian_mixture.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(lower_bound: float = -10.0, upper_bound: float = 10.0, D: int = 2, rng: np.random.Generator = None):
+    """Generates a random draw from a 2-dimensional uniform prior bounded between
+    `lower_bound` and `upper_bound` representing the common mean of a 2D Gaussian
+    mixture model (GMM).
+
+    Parameters
+    ----------
+    lower_bound : float, optional, default : -10
+        The lower bound of the uniform prior
+    upper_bound : float, optional, default : 10
+        The upper bound of the uniform prior
+    D           : int, optional, default: 2
+        The dimensionality of the mixture model
+    rng         : np.random.Generator or None, default: None
+        An optional random number generator to use
+
+    Returns
+    -------
+    params : np.ndarray of shape (D, )
+        A single draw from the D-dimensional uniform prior
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    return rng.uniform(low=lower_bound, high=upper_bound, size=D)
+
+
+def observation_model(params: np.ndarray, prob: float = 0.5, scale_c1: float = 1.0, scale_c2: float = 0.1, rng: np.random.Generator = None):
+    """Simulates data from the Gaussian mixture model (GMM) with
+    shared location vector. For more details, see
+
+    https://arxiv.org/pdf/2101.04653.pdf, Benchmark Task T.7
+
+    Important: The parameterization uses scales, so use sqrt(var),
+    if you want to be working with variances instead of scales.
+
+    Parameters
+    ----------
+    params   : np.ndarray of shape (D,)
+        The D-dimensional vector of parameter locations.
+    prob     : float, optional, default: 0.5
+        The mixture probability (coefficient).
+    scale_c1 : float, optional, default: 1.
+        The scale of the first component
+    scale_c2 : float, optional, default: 0.1
+        The scale of the second component
+    rng      : np.random.Generator or None, default: None
+        An optional random number generator to use
+
+    Returns
+    -------
+    x : np.ndarray of shape (2,)
+        The 2D vector generated from the GMM simulator.
+    """
+
+    # Use default RNG, if None specified
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Draw component index
+    idx = rng.binomial(n=1, p=prob)
+
+    # Draw 2D-Gaussian sample according to component index
+    if idx == 0:
+        return rng.normal(loc=params, scale=scale_c1)
+    return rng.normal(loc=params, scale=scale_c2)

--- a/bayesflow/benchmarks/gaussian_mixture.py
+++ b/bayesflow/benchmarks/gaussian_mixture.py
@@ -35,7 +35,9 @@ def prior(lower_bound: float = -10.0, upper_bound: float = 10.0, D: int = 2, rng
     return rng.uniform(low=lower_bound, high=upper_bound, size=D)
 
 
-def observation_model(params: np.ndarray, prob: float = 0.5, scale_c1: float = 1.0, scale_c2: float = 0.1, rng: np.random.Generator = None):
+def observation_model(
+    params: np.ndarray, prob: float = 0.5, scale_c1: float = 1.0, scale_c2: float = 0.1, rng: np.random.Generator = None
+):
     """Simulates data from the Gaussian mixture model (GMM) with
     shared location vector. For more details, see
 

--- a/bayesflow/benchmarks/inverse_kinematics.py
+++ b/bayesflow/benchmarks/inverse_kinematics.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(scales: np.ndarray = None, rng: np.random.Generator = None):
+    """Generates a random draw from a 4-dimensional Gaussian prior distribution with a
+    spherical convariance matrix. The parameters represent a robot's arm configuration,
+    with the first parameter indicating the arm's height and the remaining three are
+    angles.
+
+    Parameters
+    ----------
+    scales : np.ndarray of shape (4,) or None, optional, default : None
+        The four scales of the Gaussian prior.
+        If ``None`` provided, the scales from https://arxiv.org/pdf/2101.10763.pdf
+        will be used: [0.25, 0.5, 0.5, 0.5]
+    rng    : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    params : np.ndarray of shape (4, )
+        A single draw from the 4-dimensional Gaussian prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    if scales is None:
+        scales = np.array([0.25, 0.5, 0.5, 0.5])
+    return rng.normal(loc=0, scale=scales)
+
+
+def observation_model(params: np.ndarray, l1: float = 0.5, l2: float = 0.5, l3: float = 1.0):
+    """Returns the 2D coordinates of a robot arm given parameter vector.
+    The first parameter represents the arm's height and the remaining three
+    correspond to angles.
+
+    Parameters
+    ----------
+    params   : np.ndarray of shape (params, )
+        The four model parameters which will determine the coordinates
+    l1       : float, optional, default: 0.5
+        The length of the first segment
+    l2       : float, optional, default: 0.5
+        The length of the second segment
+    l3       : float, optional, default: 1.0
+        The length of the third segment
+
+    Returns
+    -------
+    x : np.ndarray of shape (2, )
+        The 2D coordinates of the arm
+    """
+
+    # Determine 2D position
+    x1 = l1 * np.sin(params[1])
+    x1 += l2 * np.sin(params[1] + params[2])
+    x1 += l3 * np.sin(params[1] + params[2] + params[3]) + params[0]
+    x2 = l1 * np.cos(params[1])
+    x2 += l2 * np.cos(params[1] + params[2])
+    x2 += l3 * np.cos(params[1] + params[2] + params[3])
+    return np.array([x1, x2])

--- a/bayesflow/benchmarks/lotka_volterra.py
+++ b/bayesflow/benchmarks/lotka_volterra.py
@@ -1,0 +1,104 @@
+import numpy as np
+from scipy.integrate import odeint
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(rng: np.random.Generator = None):
+    """Generates a random draw from a 4-dimensional (independent) lognormal prior
+    which represents the four contact parameters of the Lotka-Volterra model.
+
+    Parameters
+    ----------
+    rng   : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    theta : np.ndarray of shape (4,)
+        A single draw from the 4-dimensional prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+
+    theta = rng.lognormal(mean=[-0.125, -3, -0.125, -3], sigma=0.5)
+    return theta
+
+
+def _deriv(x, t, alpha, beta, gamma, delta):
+    """Helper function for scipy.integrate.odeint."""
+
+    X, Y = x
+    dX = alpha * X - beta * X * Y
+    dY = -gamma * Y + delta * X * Y
+    return dX, dY
+
+
+def observation_model(theta: np.ndarray, X0: int = 30, Y0: int = 1, T: int = 20, subsample: int = 10, flatten: bool = True, obs_noise: float = 0.1, rng: np.random.Generator = None):
+    """Runs a Lotka-Volterra simulation for T time steps and returns `subsample` evenly spaced
+    points from the simulated trajectory, given contact parameters `theta`.
+
+    See https://arxiv.org/pdf/2101.04653.pdf, Benchmark Task T.10.
+
+    Parameters
+    ----------
+    theta       : np.ndarray of shape (2,)
+        The 2-dimensional vector of disease parameters.
+    X0          : int, optional, default: 30
+        Initial number of prey species.
+    Y0          : int, optional, default: 1
+        Initial number of predator species.
+    T           : int, optional, default: 20
+        The duration (time horizon) of the simulation.
+    subsample   : int or None, optional, default: 10
+        The number of evenly spaced time points to return. If None,
+        no subsampling will be performed and all T timepoints will be returned.
+    flatten     : bool, optional, default: True
+        A flag to indicate whather a 1D (`flatten=True`) or a 2D (`flatten=False`)
+        representation of the simulated data is returned.
+    obs_noise   : float, optional, default: 0.1
+        The standard deviation of the log-normal likelihood.
+    rng         : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (subsample, 2) or (subsample*2,) if `subsample is not None`,
+        otherwise shape (T, 2) or (T*2,) if `subsample is None`.
+        The time series of simulated predator and pray populations
+    """
+
+    # Use default RNG, if None specified
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Create vector (list) of initial conditions
+    x0 = X0, Y0
+
+    # Unpack parameter vector into scalars
+    alpha, beta, gamma, delta = theta
+
+    # Prepate time vector between 0 and T of length T
+    t_vec = np.linspace(0, T, T)
+
+    # Integrate using scipy and retain only infected (2-nd dimension)
+    pp = odeint(_deriv, x0, t_vec, args=(alpha, beta, gamma, delta))
+
+    # Subsample evenly the specified number of points, if specified
+    if subsample is not None:
+        pp = pp[:: (T // subsample)]
+
+    # Ensure minimum count is 0, which will later pass by log(0 + 1)
+    pp[pp < 0] = 0.0
+
+    # Add noise, decide whether to flatten and return
+    x = rng.lognormal(np.log1p(pp), sigma=obs_noise)
+    if flatten:
+        return x.flatten()
+    return x

--- a/bayesflow/benchmarks/lotka_volterra.py
+++ b/bayesflow/benchmarks/lotka_volterra.py
@@ -40,7 +40,16 @@ def _deriv(x, t, alpha, beta, gamma, delta):
     return dX, dY
 
 
-def observation_model(theta: np.ndarray, X0: int = 30, Y0: int = 1, T: int = 20, subsample: int = 10, flatten: bool = True, obs_noise: float = 0.1, rng: np.random.Generator = None):
+def observation_model(
+    theta: np.ndarray,
+    X0: int = 30,
+    Y0: int = 1,
+    T: int = 20,
+    subsample: int = 10,
+    flatten: bool = True,
+    obs_noise: float = 0.1,
+    rng: np.random.Generator = None,
+):
     """Runs a Lotka-Volterra simulation for T time steps and returns `subsample` evenly spaced
     points from the simulated trajectory, given contact parameters `theta`.
 

--- a/bayesflow/benchmarks/lotka_volterra.py
+++ b/bayesflow/benchmarks/lotka_volterra.py
@@ -15,20 +15,20 @@ def prior(rng: np.random.Generator = None):
 
     Parameters
     ----------
-    rng   : np.random.Generator or None, default: None
+    rng    : np.random.Generator or None, default: None
         An optional random number generator to use.
 
     Returns
     -------
-    theta : np.ndarray of shape (4,)
+    params : np.ndarray of shape (4,)
         A single draw from the 4-dimensional prior.
     """
 
     if rng is None:
         rng = np.random.default_rng()
 
-    theta = rng.lognormal(mean=[-0.125, -3, -0.125, -3], sigma=0.5)
-    return theta
+    params = rng.lognormal(mean=[-0.125, -3, -0.125, -3], sigma=0.5)
+    return params
 
 
 def _deriv(x, t, alpha, beta, gamma, delta):
@@ -41,7 +41,7 @@ def _deriv(x, t, alpha, beta, gamma, delta):
 
 
 def observation_model(
-    theta: np.ndarray,
+    params: np.ndarray,
     X0: int = 30,
     Y0: int = 1,
     T: int = 20,
@@ -51,13 +51,13 @@ def observation_model(
     rng: np.random.Generator = None,
 ):
     """Runs a Lotka-Volterra simulation for T time steps and returns `subsample` evenly spaced
-    points from the simulated trajectory, given contact parameters `theta`.
+    points from the simulated trajectory, given contact parameters `params`.
 
     See https://arxiv.org/pdf/2101.04653.pdf, Benchmark Task T.10.
 
     Parameters
     ----------
-    theta       : np.ndarray of shape (2,)
+    params      : np.ndarray of shape (2,)
         The 2-dimensional vector of disease parameters.
     X0          : int, optional, default: 30
         Initial number of prey species.
@@ -91,7 +91,7 @@ def observation_model(
     x0 = X0, Y0
 
     # Unpack parameter vector into scalars
-    alpha, beta, gamma, delta = theta
+    alpha, beta, gamma, delta = params
 
     # Prepate time vector between 0 and T of length T
     t_vec = np.linspace(0, T, T)

--- a/bayesflow/benchmarks/sir.py
+++ b/bayesflow/benchmarks/sir.py
@@ -34,10 +34,10 @@ def prior(rng: np.random.Generator = None):
 def _deriv(x, t, N, beta, gamma):
     """Helper function for scipy.integrate.odeint."""
 
-    S, I, R = x
-    dS = -beta * S * I / N
-    dI = beta * S * I / N - gamma * I
-    dR = gamma * I
+    s, i, r = x
+    dS = -beta * s * i / N
+    dI = beta * s * i / N - gamma * i
+    dR = gamma * i
     return dS, dI, dR
 
 

--- a/bayesflow/benchmarks/sir.py
+++ b/bayesflow/benchmarks/sir.py
@@ -15,20 +15,20 @@ def prior(rng: np.random.Generator = None):
 
     Parameters
     ----------
-    rng   : np.random.Generator or None, default: None
+    rng    : np.random.Generator or None, default: None
         An optional random number generator to use.
 
     Returns
     -------
-    theta : np.ndarray of shape (2, )
+    params : np.ndarray of shape (2, )
         A single draw from the 2-dimensional prior.
     """
 
     if rng is None:
         rng = np.random.default_rng()
 
-    theta = rng.lognormal(mean=[np.log(0.4), np.log(1 / 8)], sigma=[0.5, 0.2])
-    return theta
+    params = rng.lognormal(mean=[np.log(0.4), np.log(1 / 8)], sigma=[0.5, 0.2])
+    return params
 
 
 def _deriv(x, t, N, beta, gamma):
@@ -42,7 +42,7 @@ def _deriv(x, t, N, beta, gamma):
 
 
 def observation_model(
-    theta: np.ndarray,
+    params: np.ndarray,
     N: float = 1e6,
     T: int = 160,
     I0: float = 1.0,
@@ -53,7 +53,7 @@ def observation_model(
     rng: np.random.Generator = None,
 ):
     """Runs a basic SIR model simulation for T time steps and returns `subsample` evenly spaced
-    points from the simulated trajectory, given disease parameters (contact and recovery rate) `theta`.
+    points from the simulated trajectory, given disease parameters (contact and recovery rate) `params`.
 
     See https://arxiv.org/pdf/2101.04653.pdf, Benchmark Task T.9.
 
@@ -61,7 +61,7 @@ def observation_model(
 
     Parameters
     ----------
-    theta          : np.ndarray of shape (2,)
+    params         : np.ndarray of shape (2,)
         The 2-dimensional vector of disease parameters.
     N              : float, optional, default: 1e6 = 1 000 000
         The size of the simulated population.
@@ -98,7 +98,7 @@ def observation_model(
     x0 = N - I0 - R0, I0, R0
 
     # Unpack parameter vector into scalars
-    beta, gamma = theta
+    beta, gamma = params
 
     # Prepate time vector between 0 and T of length T
     t_vec = np.linspace(0, T, T)

--- a/bayesflow/benchmarks/sir.py
+++ b/bayesflow/benchmarks/sir.py
@@ -1,0 +1,111 @@
+import numpy as np
+from scipy.integrate import odeint
+
+
+def simulator():
+    """Non-configurable simulator running with default settings"""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(rng: np.random.Generator = None):
+    """Generates a random draw from a 2-dimensional (independent) lognormal prior
+    which represents the contact and recovery rate parameters of a basic SIR model.
+
+    Parameters
+    ----------
+    rng   : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    theta : np.ndarray of shape (2, )
+        A single draw from the 2-dimensional prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+
+    theta = rng.lognormal(mean=[np.log(0.4), np.log(1 / 8)], sigma=[0.5, 0.2])
+    return theta
+
+
+def _deriv(x, t, N, beta, gamma):
+    """Helper function for scipy.integrate.odeint."""
+
+    S, I, R = x
+    dS = -beta * S * I / N
+    dI = beta * S * I / N - gamma * I
+    dR = gamma * I
+    return dS, dI, dR
+
+
+def observation_model(theta: np.ndarray, N: float = 1e6, T: int = 160, I0: float = 1.0, R0: float = 0.0,
+        subsample: int = 10, total_count: int = 1000, scale_by_total: bool = True, rng: np.random.Generator = None):
+    """Runs a basic SIR model simulation for T time steps and returns `subsample` evenly spaced
+    points from the simulated trajectory, given disease parameters (contact and recovery rate) `theta`.
+
+    See https://arxiv.org/pdf/2101.04653.pdf, Benchmark Task T.9.
+
+    Note, that the simulator will scale the outputs between 0 and 1.
+
+    Parameters
+    ----------
+    theta          : np.ndarray of shape (2,)
+        The 2-dimensional vector of disease parameters.
+    N              : float, optional, default: 1e6 = 1 000 000
+        The size of the simulated population.
+    T              : T, optional, default: 160
+        The duration (time horizon) of the simulation.
+    I0             : float, optional, default: 1.
+        The number of initially infected individuals.
+    R0             : float, optional, default: 0.
+        The number of initially recovered individuals.
+    subsample      : int or None, optional, default: 10
+        The number of evenly spaced time points to return. If None,
+        no subsampling will be performed and all T timepoints will be returned.
+    total_count    : int, optional, default: 1000
+        The N parameter of the binomial noise distribution. Used just
+        for scaling the data and magnifying the effect of noise, such that
+        max infected == total_count.
+    scale_by_total : bool, optional, default: True
+        Scales the outputs by ``total_count`` if set to True.
+    rng            : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (subsample,) or (T,) if subsample=None
+        The time series of simulated infected individuals. A trailing dimension of 1 should
+        be added by a BayesFlow configurator if the data is (properly) to be treated as time series.
+    """
+
+    # Use default RNG, if None specified
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Create vector (list) of initial conditions
+    x0 = N - I0 - R0, I0, R0
+
+    # Unpack parameter vector into scalars
+    beta, gamma = theta
+
+    # Prepate time vector between 0 and T of length T
+    t_vec = np.linspace(0, T, T)
+
+    # Integrate using scipy and retain only infected (2-nd dimension)
+    irt = odeint(_deriv, x0, t_vec, args=(N, beta, gamma))[:, 1]
+
+    # Subsample evenly the specified number of points, if specified
+    if subsample is not None:
+        irt = irt[:: (T // subsample)]
+
+    # Truncate irt, so that small underflow below zero becomes zero
+    irt = np.maximum(irt, 0.0)
+
+    # Add noise and scale, if indicated
+    x = rng.binomial(n=total_count, p=irt / N)
+    if scale_by_total:
+        x = x / total_count
+    return x

--- a/bayesflow/benchmarks/sir.py
+++ b/bayesflow/benchmarks/sir.py
@@ -41,8 +41,17 @@ def _deriv(x, t, N, beta, gamma):
     return dS, dI, dR
 
 
-def observation_model(theta: np.ndarray, N: float = 1e6, T: int = 160, I0: float = 1.0, R0: float = 0.0,
-        subsample: int = 10, total_count: int = 1000, scale_by_total: bool = True, rng: np.random.Generator = None):
+def observation_model(
+    theta: np.ndarray,
+    N: float = 1e6,
+    T: int = 160,
+    I0: float = 1.0,
+    R0: float = 0.0,
+    subsample: int = 10,
+    total_count: int = 1000,
+    scale_by_total: bool = True,
+    rng: np.random.Generator = None,
+):
     """Runs a basic SIR model simulation for T time steps and returns `subsample` evenly spaced
     points from the simulated trajectory, given disease parameters (contact and recovery rate) `theta`.
 

--- a/bayesflow/benchmarks/slcp.py
+++ b/bayesflow/benchmarks/slcp.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def prior(lower_bound: float = -3.0, upper_bound: float = 3.0, rng: np.random.Generator = None):
+    """Generates a random draw from a 5-dimensional uniform prior bounded between
+    `lower_bound` and `upper_bound` which represents the 5 parameters of the SLCP
+    simulator.
+
+    Parameters
+    ----------
+    lower_bound : float, optional, default : -3
+        The lower bound of the uniform prior.
+    upper_bound : float, optional, default : 3
+        The upper bound of the uniform prior.
+    rng         : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    params : np.ndarray of shape (5, )
+        A single draw from the 5-dimensional uniform prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    return rng.uniform(low=lower_bound, high=upper_bound, size=5)
+
+
+def observation_model(params: np.ndarray, n_obs: int = 4, flatten: bool = True, rng: np.random.Generator = None):
+    """Generates data from the SLCP model designed as a benchmark for a simple likelihood
+    and a complex posterior due to a non-linear pushforward params -> x.
+
+    See https://arxiv.org/pdf/2101.04653.pdf, Benchmark Task T.3
+
+    Parameters
+    ----------
+    params  : np.ndarray of shape (params, D)
+        The location parameters of the Gaussian likelihood.
+    n_obs   : int, optional, default: 4
+        The number of observations to generate from the slcp likelihood.
+    flatten : bool, optional, default: True
+        A flag to indicate whather a 1D (`flatten=True`) or a 2D (`flatten=False`)
+        representation of the simulated data is returned.
+    rng     : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (n_obs*2, ) or (n_obs, 2), as indictated by the `flatten`
+        boolean flag. The sample of simulated data from the SLCP model.
+    """
+
+    # Use default RNG, if None specified
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Specify 2D location
+    loc = np.array([params[0], params[1]])
+
+    # Specify 2D covariance matrix
+    s1 = params[2] ** 2
+    s2 = params[3] ** 2
+    rho = np.tanh(params[4])
+    cov = rho * s1 * s2
+    S_param = np.array([[s1**2, cov], [cov, s2**2]])
+
+    # Obtain given number of draws from the MVN likelihood
+    x = rng.multivariate_normal(loc, S_param, size=n_obs)
+    if flatten:
+        return x.flatten()
+    return x

--- a/bayesflow/benchmarks/slcp_distractors.py
+++ b/bayesflow/benchmarks/slcp_distractors.py
@@ -9,7 +9,9 @@ def simulator():
     return dict(parameters=prior_draws, observables=observables)
 
 
-def get_random_student_t(dim: int = 2, mu_scale: float = 15., shape_scale: float = 0.01, rng: np.random.Generator = None):
+def get_random_student_t(
+    dim: int = 2, mu_scale: float = 15.0, shape_scale: float = 0.01, rng: np.random.Generator = None
+):
     """A helper function to create a "frozen" multivariate student-t distribution of dimensions `dim`.
 
     Parameters
@@ -42,7 +44,9 @@ def get_random_student_t(dim: int = 2, mu_scale: float = 15., shape_scale: float
     return multivariate_t(loc=mu, shape=shape_scale, df=2, allow_singular=True, seed=rng)
 
 
-def draw_mixture_student_t(num_students: int, n_draws: int = 46, dim: int = 2, mu_scale: float = 15.0, rng: np.random.Generator = None):
+def draw_mixture_student_t(
+    num_students: int, n_draws: int = 46, dim: int = 2, mu_scale: float = 15.0, rng: np.random.Generator = None
+):
     """Helper function to generate `n_draws` random draws from a mixture of `num_students`
     multivariate Student-t distributions.
 
@@ -105,7 +109,15 @@ def prior(lower_bound: float = -3.0, upper_bound: float = 3.0, rng: np.random.Ge
     return rng.uniform(low=lower_bound, high=upper_bound, size=5)
 
 
-def observation_model(params: np.ndarray, n_obs: int = 4, n_dist: int = 46, dim: int = 2, mu_scale: float = 15.0, flatten: bool = True, rng: np.random.Generator = None):
+def observation_model(
+    params: np.ndarray,
+    n_obs: int = 4,
+    n_dist: int = 46,
+    dim: int = 2,
+    mu_scale: float = 15.0,
+    flatten: bool = True,
+    rng: np.random.Generator = None,
+):
     """Generates data from the SLCP model designed as a benchmark for a simple likelihood
     and a complex posterior due to a non-linear pushforward params -> x. In addition, it
     outputs uninformative distractor data.

--- a/bayesflow/benchmarks/slcp_distractors.py
+++ b/bayesflow/benchmarks/slcp_distractors.py
@@ -1,0 +1,164 @@
+import numpy as np
+from scipy.stats import multivariate_t
+
+
+def simulator():
+    """Non-configurable simulator running with default settings."""
+    prior_draws = prior()
+    observables = observation_model(prior_draws)
+    return dict(parameters=prior_draws, observables=observables)
+
+
+def get_random_student_t(dim: int = 2, mu_scale: float = 15., shape_scale: float = 0.01, rng: np.random.Generator = None):
+    """A helper function to create a "frozen" multivariate student-t distribution of dimensions `dim`.
+
+    Parameters
+    ----------
+    dim          : int, optional, default: 2
+        The dimensionality of the student-t distribution.
+    mu_scale     : float, optional, default: 15
+        The scale of the zero-centered Gaussian prior from which the mean vector
+        of the student-t distribution is drawn.
+    shape_scale  : float, optional, default: 0.01
+        The scale of the assumed `np.eye(dim)` shape matrix. The default is chosen to keep
+        the scale of the distractors and observations relatively similar.
+    rng          : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    student : callable (scipy.stats._multivariate.multivariate_t_frozen)
+        The student-t generator.
+    """
+
+    # Use default RNG, if None provided
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Draw mean
+    mu = mu_scale * rng.normal(size=dim)
+
+    # Return student-t object
+    return multivariate_t(loc=mu, shape=shape_scale, df=2, allow_singular=True, seed=rng)
+
+
+def draw_mixture_student_t(num_students: int, n_draws: int = 46, dim: int = 2, mu_scale: float = 15.0, rng: np.random.Generator = None):
+    """Helper function to generate `n_draws` random draws from a mixture of `num_students`
+    multivariate Student-t distributions.
+
+    Uses the function `get_random_student_t` to create each of the studen-t callable objects.
+
+    Parameters
+    ----------
+    num_students : int
+        The number of multivariate student-t mixture components
+    n_draws      : int, optional, default: 46
+        The number of draws to obtain from the mixture distribution.
+    dim          : int, optional, default: 2
+        The dimensionality of each student-t distribution in the mixture.
+    mu_scale     : float, optional, default: 15
+        The scale of the zero-centered Gaussian prior from which the mean vector
+        of each student-t distribution in the mixture is drawn.
+    rng          : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    sample : np.ndarray of shape (n_draws, dim)
+        The random draws from the mixture of students.
+    """
+
+    # Use default RNG, if None provided
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Obtain a list of scipy frozen distributions (each will have a different mean)
+    students = [get_random_student_t(dim, mu_scale, rng=rng) for _ in range(num_students)]
+
+    # Obtain the sample of n_draws from the mixture and return
+    sample = [students[rng.integers(low=0, high=num_students)].rvs() for _ in range(n_draws)]
+
+    return np.array(sample)
+
+
+def prior(lower_bound: float = -3.0, upper_bound: float = 3.0, rng: np.random.Generator = None):
+    """Generates a random draw from a 5-dimensional uniform prior bounded between
+    `lower_bound` and `upper_bound`.
+
+    Parameters
+    ----------
+    lower_bound : float, optional, default : -3
+        The lower bound of the uniform prior.
+    upper_bound : float, optional, default : 3
+        The upper bound of the uniform prior.
+    rng         : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    params : np.ndarray of shape (5, )
+        A single draw from the 5-dimensional uniform prior.
+    """
+
+    if rng is None:
+        rng = np.random.default_rng()
+    return rng.uniform(low=lower_bound, high=upper_bound, size=5)
+
+
+def observation_model(params: np.ndarray, n_obs: int = 4, n_dist: int = 46, dim: int = 2, mu_scale: float = 15.0, flatten: bool = True, rng: np.random.Generator = None):
+    """Generates data from the SLCP model designed as a benchmark for a simple likelihood
+    and a complex posterior due to a non-linear pushforward params -> x. In addition, it
+    outputs uninformative distractor data.
+
+    See https://arxiv.org/pdf/2101.04653.pdf, Benchmark Task T.4
+
+    Parameters
+    ----------
+    params   : np.ndarray of shape (params, D)
+        The location parameters of the Gaussian likelihood.
+    n_obs    : int, optional, default: 4
+        The number of observations to generate from the slcp likelihood.
+    n_dist   : int, optional, default: 46
+        The number of distractor to draw from the distractor likelihood.
+    dim      : int, optional, default: 2
+        The dimensionality of each student-t distribution in the mixture.
+    mu_scale : float, optional, default: 15
+        The scale of the zero-centered Gaussian prior from which the mean vector
+        of each student-t distribution in the mixture is drawn.
+    flatten  : bool, optional, default: True
+        A flag to indicate whather a 1D (`flatten=True`) or a 2D (`flatten=False`)
+        representation of the simulated data is returned.
+    rng      : np.random.Generator or None, default: None
+        An optional random number generator to use.
+
+    Returns
+    -------
+    x : np.ndarray of shape (n_obs*2 + n_dist*2,) if `flatten=True`, otherwise
+        np.ndarray of shape (n_obs + n_dist, 2) if `flatten=False`
+    """
+
+    # Use default RNG, if None specified
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # Specify 2D location
+    loc = np.array([params[0], params[1]])
+
+    # Specify 2D covariance matrix
+    s1 = params[2] ** 2
+    s2 = params[3] ** 2
+    rho = np.tanh(params[4])
+    cov = rho * s1 * s2
+    S_param = np.array([[s1**2, cov], [cov, s2**2]])
+
+    # Obtain informative part of the data
+    x_info = rng.multivariate_normal(loc, S_param, size=n_obs)
+
+    # Obtain uninformative part of the data
+    x_uninfo = draw_mixture_student_t(num_students=20, n_draws=n_dist, dim=dim, mu_scale=mu_scale, rng=rng)
+
+    # Concatenate informative with uninformative and return
+    x = np.concatenate([x_info, x_uninfo], axis=0)
+    if flatten:
+        return x.flatten()
+    return x


### PR DESCRIPTION
Jira BF-49
Refactor benchmarks from `master` 

Changes:
- Updated docs in `benchmark.py`
- Added `bernoulli_glm.py`
- Added `bernoulli_glm_raw.py`
- Added `gaussian_linear.py`
- Added `gaussian_linear_uniform.py`
- Added `gaussian_mixture.py`
- Added `inverse_kinematics.py`
- Added `lotka_volterra.py`
- Added `sir.py`
- Added `slcp.py`
- Added `slcp_distractors.py`

Notes:
An issue should be opened for adding kwargs support s.t. the simulators don't only run on defaults