### PR TITLE
Make pip-installable via GitHub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,5 +120,5 @@ docstring-code-format = true
 # enabled.
 docstring-code-line-length = "dynamic"
 
-[tool.setuptools]
-py-modules = []
+[tool.setuptools.packages]
+find = {}


### PR DESCRIPTION
This makes the `dev` version of BayesFlow pip-installable directly from GitHub via

```
pip install git+https://github.com/stefanradev93/BayesFlow@dev
```

This PR closes issue https://github.com/stefanradev93/BayesFlow/issues/188.