### PR TITLE
Implement DiagonalStudentT.sample method natively in keras

### DIFF
--- a/bayesflow/distributions/diagonal_student_t.py
+++ b/bayesflow/distributions/diagonal_student_t.py
@@ -90,8 +90,8 @@ class DiagonalStudentT(Distribution):
         # chi-square(df) = Gamma(shape = 0.5 * df, scale = 2) = Gamma(shape = 0.5 * df, scale = 1) * 2
         chi2_samples = keras.random.gamma(batch_shape, alpha=0.5 * self.df, seed=self.seed_generator) * 2.0
 
-        # the chi-quare samples needs to be repeated across self.dim
-        # since for each element of batch_shape only one sample is created
+        # The chi-quare samples need to be repeated across self.dim
+        # since for each element of batch_shape only one sample is created.
         chi2_samples = expand_tile(chi2_samples, n=self.dim, axis=-1)
 
         normal_samples = keras.random.normal(batch_shape + (self.dim,), seed=self.seed_generator)


### PR DESCRIPTION
When trying to run .sample of the student_t distribution the torch backend complained about some incompatible types, presumably because scipy and torch types did not like each other. So I went ahead and implemented the sample method natively using keras functions using the fact that chi-square samples can be obtained for standard gamma samples which are implemented in keras.

Here is a small test providing evidence for the implementation's correctness:

```python
import keras
import numpy as np

## REMOVE ON PRODUCTION
import sys
sys.path.append('../')

import bayesflow as bf

t = bf.distributions.DiagonalStudentT(df = 10, loc = 1.0, scale = 3.0)
t.build(input_shape = (3,))

y = t.sample((100000, ))
y.shape
y.mean(dim = 0)
y.var(dim = 0)

# analytical variance:
# 3.0**2.0 * 10.0 / (10.0 - 2.0) = 11.25
```

@LarsKue can you review this PR? Specifically, can you check whether my shape broadcasting is correct? I assume there is a better pattern than repeat and reshape for what I want to achieve.
