### PR TITLE
add optional time embedding layer to consistency model

### DIFF
--- a/bayesflow/experimental/stable_consistency_model/stable_consistency_model.py
+++ b/bayesflow/experimental/stable_consistency_model/stable_consistency_model.py
@@ -108,10 +108,8 @@ class StableConsistencyModel(InferenceNetwork):
         )
 
         embedding_kwargs = embedding_kwargs or {}
-        if time_emb is not None:
-            self.time_emb = time_emb
-        else:
-            self.time_emb = FourierEmbedding(**embedding_kwargs)
+        self.time_emb = time_emb or FourierEmbedding(**embedding_kwargs)
+
         self.time_emb_dim = self.time_emb.embed_dim
 
         self.sigma = sigma


### PR DESCRIPTION
This pull request introduces a new option to provide a custom time embedding layer to the `StableConsistencyModel` class, improving its flexibility and configurability.  This also fixes a bug while loading a non-default `FourierEmbedding`.