### PR TITLE
Sample method determinism

### DIFF
--- a/bayesflow/approximators/approximator.py
+++ b/bayesflow/approximators/approximator.py
@@ -19,7 +19,7 @@ from .backend_approximators import BackendApproximator
 class Approximator(BackendApproximator):
     """Base class for all BayesFlow approximators."""
 
-    # Mask routing: {data_key → network_kwarg_name}.
+    # Mask routing: {data_key -> network_kwarg_name}.
     # Subclasses can narrow these to the masks they actually support.
     _SUMMARY_MASK_KEYS: dict[str, str] = {
         "summary_attention_mask": "attention_mask",

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -234,7 +234,7 @@ class ContinuousApproximator(Approximator):
         seed : int, keras.random.SeedGenerator, or None, optional
             Seed for reproducible sampling. An integer is converted to a ``keras.random.SeedGenerator``
             and shared across all stochastic operations in the call. A ``SeedGenerator`` is passed through
-            as-is. If ``None`` (default), each component uses its own instance seed generator or a global one.
+            as-is. If ``None`` (default), each component uses its own instance seed generator.
         **kwargs : dict
             Additional keyword arguments for the sampling process.
 

--- a/bayesflow/approximators/continuous_approximator.py
+++ b/bayesflow/approximators/continuous_approximator.py
@@ -9,6 +9,7 @@ from bayesflow.adapters import Adapter
 from bayesflow.networks import InferenceNetwork, SummaryNetwork
 from bayesflow.types import Tensor
 from bayesflow.utils import split_arrays
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serialize, serializable
 
 from .approximator import Approximator
@@ -200,6 +201,7 @@ class ContinuousApproximator(Approximator):
         batch_size: int | None = None,
         sample_shape: Literal["infer"] | Tuple[int] | int = "infer",
         return_summaries: bool = False,
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs,
     ) -> dict[str, np.ndarray]:
         """
@@ -229,6 +231,10 @@ class ContinuousApproximator(Approximator):
         return_summaries: bool, optional
             If set to True and a summary network is present, will return the learned summary statistics for
             the provided conditions.
+        seed : int, keras.random.SeedGenerator, or None, optional
+            Seed for reproducible sampling. An integer is converted to a ``keras.random.SeedGenerator``
+            and shared across all stochastic operations in the call. A ``SeedGenerator`` is passed through
+            as-is. If ``None`` (default), each component uses its own instance seed generator or a global one.
         **kwargs : dict
             Additional keyword arguments for the sampling process.
 
@@ -248,6 +254,7 @@ class ContinuousApproximator(Approximator):
             conditions=resolved_conditions,
             batch_size=batch_size,
             sample_shape=sample_shape,
+            seed=resolve_seed(seed),
             **inference_kwargs,
         )
 

--- a/bayesflow/approximators/ensemble_approximator.py
+++ b/bayesflow/approximators/ensemble_approximator.py
@@ -10,6 +10,7 @@ from bayesflow.adapters import Adapter
 from bayesflow.simulators import Simulator
 from bayesflow.types import Tensor
 from bayesflow.utils import logging, filter_kwargs
+from bayesflow.utils.keras_utils import resolve_seed, keras_multinomial
 from bayesflow.utils.serialization import serializable, serialize
 from bayesflow.datasets import EnsembleDataset
 
@@ -230,6 +231,7 @@ class EnsembleApproximator(Approximator):
         split: bool = False,
         member_weights: Mapping[str, float] | None = None,
         merge_members: bool = True,
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs,
     ) -> dict[str, np.ndarray]:
         """
@@ -268,23 +270,27 @@ class EnsembleApproximator(Approximator):
                 fn=lambda name, a: a.sample(num_samples=num_samples, conditions=conditions, split=split, **kwargs),
             )
 
+        seed_generator = resolve_seed(seed)
+
         weights = self._resolve_member_weights(member_weights)
         names = tuple(weights.keys())
-        probs = np.fromiter(weights.values(), dtype=float, count=len(weights))
+        probs = np.array(list(weights.values()))
 
-        counts = np.random.multinomial(num_samples, probs)
+        counts = keras_multinomial(num_samples, probs, seed=seed_generator)
         alloc = {name: int(count) for name, count in zip(names, counts) if count > 0}
 
         per_member = self._map_members(
             list(alloc.keys()),
             capability="distribution",
-            fn=lambda name, a: a.sample(num_samples=alloc[name], conditions=conditions, split=split, **kwargs),
+            fn=lambda name, a: a.sample(
+                num_samples=alloc[name], conditions=conditions, split=split, seed=seed_generator, **kwargs
+            ),
         )
 
         merged = keras.tree.map_structure(lambda *xs: np.concatenate(xs, axis=1), *list(per_member.values()))
-        idx = np.random.permutation(num_samples)
+        shuffle_idx = keras.random.shuffle(keras.ops.arange(num_samples), seed=seed_generator)
 
-        return keras.tree.map_structure(lambda a: np.take(a, idx, axis=1), merged)
+        return keras.tree.map_structure(lambda a: np.take(a, shuffle_idx, axis=1), merged)
 
     def log_prob(
         self,

--- a/bayesflow/approximators/ensemble_approximator.py
+++ b/bayesflow/approximators/ensemble_approximator.py
@@ -10,7 +10,7 @@ from bayesflow.adapters import Adapter
 from bayesflow.simulators import Simulator
 from bayesflow.types import Tensor
 from bayesflow.utils import logging, filter_kwargs
-from bayesflow.utils.keras_utils import resolve_seed, keras_multinomial
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serializable, serialize
 from bayesflow.datasets import EnsembleDataset
 
@@ -276,7 +276,13 @@ class EnsembleApproximator(Approximator):
         names = tuple(weights.keys())
         probs = np.array(list(weights.values()))
 
-        counts = keras_multinomial(num_samples, probs, seed=seed_generator)
+        # Sample counts from multinomial
+        K = len(probs)
+        logits_broadcast = keras.ops.broadcast_to(keras.ops.expand_dims(keras.ops.log(probs), axis=0), (num_samples, K))
+        cat_indices = keras.ops.squeeze(keras.random.categorical(logits_broadcast, num_samples=1, seed=seed), axis=-1)
+        one_hot = keras.ops.one_hot(cat_indices, K)
+        counts = keras.ops.sum(one_hot, axis=0)
+
         alloc = {name: int(count) for name, count in zip(names, counts) if count > 0}
 
         per_member = self._map_members(

--- a/bayesflow/approximators/helpers/samplers.py
+++ b/bayesflow/approximators/helpers/samplers.py
@@ -75,6 +75,7 @@ class Sampler:
         conditions: Tensor | None = None,
         batch_size: int | None = None,
         sample_shape: Literal["infer"] | Sequence[int] | int = "infer",
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs,
     ):
         if conditions is None:
@@ -83,6 +84,7 @@ class Sampler:
                 num_samples=num_samples,
                 conditions=None,
                 sample_shape=sample_shape,
+                seed=seed,
                 **kwargs,
             )
 
@@ -103,6 +105,7 @@ class Sampler:
                 num_samples=num_samples,
                 conditions=batch_conditions,
                 sample_shape=sample_shape,
+                seed=seed,
                 **batch_kwargs,
             )
             batches.append(batch_samples)
@@ -116,6 +119,7 @@ class Sampler:
         num_samples: int,
         conditions: Tensor | None,
         sample_shape: Literal["infer"] | Sequence[int] | int,
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs,
     ):
         conditions = self.repeat_and_flatten_conditions(conditions, num_samples)
@@ -137,7 +141,7 @@ class Sampler:
         sample_shape = self.infer_sample_shape(conditions, sample_shape)
         batch_shape = batch_shape + sample_shape
 
-        samples = inference_network.sample(batch_shape, conditions=conditions, **kwargs)
+        samples = inference_network.sample(batch_shape, conditions=conditions, seed=seed, **kwargs)
 
         if conditions is not None:
             samples = self.unflatten_samples(samples, num_samples)

--- a/bayesflow/approximators/scoring_rule_approximator.py
+++ b/bayesflow/approximators/scoring_rule_approximator.py
@@ -12,7 +12,7 @@ from bayesflow.utils import (
     split_arrays,
     squeeze_inner_estimates_dict,
 )
-from bayesflow.utils.keras_utils import resolve_seed, keras_multinomial
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serializable
 
 from .continuous_approximator import ContinuousApproximator
@@ -63,8 +63,8 @@ class ScoringRuleApproximator(ContinuousApproximator):
 
         self.distribution_keys = []
         for score_key, score in self.inference_network.scoring_rules.items():
-            has_sample = getattr(score, "sample", None)
-            has_log_prob = getattr(score, "log_prob", None)
+            has_sample = callable(getattr(score, "sample", None))
+            has_log_prob = callable(getattr(score, "log_prob", None))
 
             if has_sample and has_log_prob:
                 self.distribution_keys.append(score_key)
@@ -220,7 +220,6 @@ class ScoringRuleApproximator(ContinuousApproximator):
             return self._sample_separate(num_samples=num_samples, conditions=conditions, split=split, **kwargs)
 
         seed_generator = resolve_seed(seed)
-        score_weights = self._resolve_score_weights(score_weights)
 
         # Single score: _sample_separate already squeezed to a plain result,
         # and mixing with uniform weight is an identity operation.
@@ -229,9 +228,19 @@ class ScoringRuleApproximator(ContinuousApproximator):
                 num_samples=num_samples, conditions=conditions, split=split, seed=seed_generator, **kwargs
             )
 
-        # Allocate samples per score and draw only as many as needed (max over scores).
+        # Allocate samples per score according to weights
+        score_weights = self._resolve_score_weights(score_weights)
         probs = np.array(list(score_weights.values()))
-        counts = keras_multinomial(num_samples, probs, seed=seed_generator)
+
+        # Sample counts from multinomial
+        K = len(probs)
+        logits_broadcast = keras.ops.broadcast_to(keras.ops.expand_dims(keras.ops.log(probs), axis=0), (num_samples, K))
+        cat_indices = keras.ops.squeeze(
+            keras.random.categorical(logits_broadcast, num_samples=1, seed=seed_generator), axis=-1
+        )
+        one_hot = keras.ops.one_hot(cat_indices, K)
+        counts = keras.ops.sum(one_hot, axis=0)
+
         max_count = int(keras.ops.max(counts))
         num_samples_per_score = {k: counts[i] for i, k in enumerate(score_weights.keys())}
 

--- a/bayesflow/approximators/scoring_rule_approximator.py
+++ b/bayesflow/approximators/scoring_rule_approximator.py
@@ -12,6 +12,7 @@ from bayesflow.utils import (
     split_arrays,
     squeeze_inner_estimates_dict,
 )
+from bayesflow.utils.keras_utils import resolve_seed, keras_multinomial
 from bayesflow.utils.serialization import serializable
 
 from .continuous_approximator import ContinuousApproximator
@@ -62,8 +63,8 @@ class ScoringRuleApproximator(ContinuousApproximator):
 
         self.distribution_keys = []
         for score_key, score in self.inference_network.scoring_rules.items():
-            has_sample = callable(getattr(score, "sample", None))
-            has_log_prob = callable(getattr(score, "log_prob", None))
+            has_sample = getattr(score, "sample", None)
+            has_log_prob = getattr(score, "log_prob", None)
 
             if has_sample and has_log_prob:
                 self.distribution_keys.append(score_key)
@@ -156,6 +157,7 @@ class ScoringRuleApproximator(ContinuousApproximator):
         split: bool = False,
         score_weights: Mapping[str, float] | None = None,
         merge_scores: bool = True,
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs,
     ) -> dict[str, np.ndarray] | dict[str, dict[str, np.ndarray]]:
         """
@@ -217,37 +219,49 @@ class ScoringRuleApproximator(ContinuousApproximator):
                 )
             return self._sample_separate(num_samples=num_samples, conditions=conditions, split=split, **kwargs)
 
+        seed_generator = resolve_seed(seed)
         score_weights = self._resolve_score_weights(score_weights)
 
         # Single score: _sample_separate already squeezed to a plain result,
         # and mixing with uniform weight is an identity operation.
         if len(self.distribution_keys) == 1:
-            return self._sample_separate(num_samples=num_samples, conditions=conditions, split=split, **kwargs)
+            return self._sample_separate(
+                num_samples=num_samples, conditions=conditions, split=split, seed=seed_generator, **kwargs
+            )
 
         # Allocate samples per score and draw only as many as needed (max over scores).
-        num_samples_per_score = np.random.multinomial(num_samples, list(score_weights.values()))
-        max_k = int(np.max(num_samples_per_score))
-        num_samples_per_score = {k: num_samples_per_score[i] for i, k in enumerate(score_weights.keys())}
+        probs = np.array(list(score_weights.values()))
+        counts = keras_multinomial(num_samples, probs, seed=seed_generator)
+        max_count = int(keras.ops.max(counts))
+        num_samples_per_score = {k: counts[i] for i, k in enumerate(score_weights.keys())}
 
-        samples_by_score = self._sample_separate(num_samples=max_k, conditions=conditions, split=split, **kwargs)
+        samples_by_score = self._sample_separate(
+            num_samples=max_count, conditions=conditions, split=split, seed=seed_generator, **kwargs
+        )
 
         # Crop each score's samples down to its allocated k
         cropped_list = []
         for score_key, k in num_samples_per_score.items():
             if k == 0:
                 continue
-            cropped = keras.tree.map_structure(lambda arr: arr[:, :k], samples_by_score[score_key])
+            cropped = keras.tree.map_structure(
+                lambda arr, k=k: keras.ops.take(arr, keras.ops.arange(keras.ops.cast(k, "int32")), axis=1),
+                samples_by_score[score_key],
+            )
             cropped_list.append(cropped)
 
         # Concatenate across scores along the sample axis.
         concatenated = keras.tree.map_structure(
-            lambda *arrays: np.concatenate(arrays, axis=1),
+            lambda *arrays: keras.ops.concatenate(arrays, axis=1),
             *cropped_list,
         )
 
         # Shuffle along the sample axis (1) to form the mixture samples.
-        shuffle_idx = np.random.permutation(num_samples)
-        shuffled = keras.tree.map_structure(lambda arr: np.take(arr, shuffle_idx, axis=1), concatenated)
+        shuffle_idx = keras.random.shuffle(keras.ops.arange(num_samples), seed=seed_generator)
+        shuffled = keras.tree.map_structure(
+            lambda arr: keras.ops.convert_to_numpy(keras.ops.take(arr, shuffle_idx, axis=1)),
+            concatenated,
+        )
         return shuffled
 
     def _sample_separate(
@@ -257,6 +271,7 @@ class ScoringRuleApproximator(ContinuousApproximator):
         conditions: Mapping[str, np.ndarray] | None = None,
         split: bool = False,
         batch_size: int | None = None,
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs,
     ) -> dict[str, np.ndarray | dict[str, np.ndarray]]:
         """
@@ -298,6 +313,7 @@ class ScoringRuleApproximator(ContinuousApproximator):
             num_samples=num_samples,
             conditions=conditions,
             split=False,
+            seed=seed,
             batch_size=batch_size,
             **kwargs,
         )

--- a/bayesflow/distributions/diagonal_normal.py
+++ b/bayesflow/distributions/diagonal_normal.py
@@ -7,6 +7,7 @@ from keras import ops
 
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils.decorators import allow_batch_size
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serializable, serialize
 
 from .distribution import Distribution
@@ -21,7 +22,7 @@ class DiagonalNormal(Distribution):
         mean: int | float | np.ndarray | Tensor = 0.0,
         std: int | float | np.ndarray | Tensor = 1.0,
         trainable_parameters: bool = False,
-        seed_generator: keras.random.SeedGenerator = None,
+        seed_generator: keras.random.SeedGenerator | None = None,
         **kwargs,
     ):
         """
@@ -97,8 +98,9 @@ class DiagonalNormal(Distribution):
         return result
 
     @allow_batch_size
-    def sample(self, batch_shape: Shape) -> Tensor:
-        z = keras.random.normal(shape=batch_shape + (self.dim,), seed=self.seed_generator)
+    def sample(self, batch_shape: Shape, seed: int | keras.random.SeedGenerator | None = None) -> Tensor:
+        sg = resolve_seed(seed) or self.seed_generator
+        z = keras.random.normal(shape=batch_shape + (self.dim,), seed=sg)
         z = self._mean + self._std * z
         return z
 

--- a/bayesflow/distributions/diagonal_student_t.py
+++ b/bayesflow/distributions/diagonal_student_t.py
@@ -8,6 +8,7 @@ from keras import ops
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils import expand_tile
 from bayesflow.utils.decorators import allow_batch_size
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serializable, serialize
 
 from .distribution import Distribution
@@ -23,7 +24,7 @@ class DiagonalStudentT(Distribution):
         loc: int | float | np.ndarray | Tensor = 0.0,
         scale: int | float | np.ndarray | Tensor = 1.0,
         trainable_parameters: bool = False,
-        seed_generator: keras.random.SeedGenerator = None,
+        seed_generator: keras.random.SeedGenerator | None = None,
         **kwargs,
     ):
         """
@@ -111,18 +112,19 @@ class DiagonalStudentT(Distribution):
         return result
 
     @allow_batch_size
-    def sample(self, batch_shape: Shape) -> Tensor:
+    def sample(self, batch_shape: Shape, seed: int | keras.random.SeedGenerator | None = None) -> Tensor:
+        sg = resolve_seed(seed) or self.seed_generator
         # As of writing this code, keras does not support the chi-square distribution
         # nor does it support a scale or rate parameter in Gamma. Hence, we use the relation:
         # chi-square(df) = Gamma(shape = 0.5 * df, scale = 2) = Gamma(shape = 0.5 * df, scale = 1) * 2
-        chi2_samples = keras.random.gamma(batch_shape, alpha=0.5 * self.df, seed=self.seed_generator) * 2.0
+        chi2_samples = keras.random.gamma(batch_shape, alpha=0.5 * self.df, seed=sg) * 2.0
 
         # The chi-quare samples need to be repeated across self.dim
         # since for each element of batch_shape only one sample is created.
         chi2_samples = expand_tile(chi2_samples, n=self.dim, axis=-1)
         chi2_samples = keras.ops.reshape(chi2_samples, batch_shape + (self.dim,))
 
-        normal_samples = keras.random.normal(batch_shape + (self.dim,), seed=self.seed_generator)
+        normal_samples = keras.random.normal(batch_shape + (self.dim,), seed=sg)
 
         return self._loc + self._scale * normal_samples * ops.sqrt(self.df / chi2_samples)
 

--- a/bayesflow/distributions/distribution.py
+++ b/bayesflow/distributions/distribution.py
@@ -16,7 +16,26 @@ class Distribution(keras.Layer):
     def log_prob(self, samples: Tensor, *, normalize: bool = True) -> Tensor:
         raise NotImplementedError
 
-    def sample(self, batch_shape: Shape) -> Tensor:
+    def sample(self, batch_shape: Shape, seed: int | keras.random.SeedGenerator | None = None) -> Tensor:
+        """Draw samples from the distribution.
+
+        Parameters
+        ----------
+        batch_shape : Shape
+            The desired sample batch shape (tuple of ints), not including the
+            event dimension.
+        seed : int, keras.random.SeedGenerator, or None, optional
+            Seed for reproducible sampling. An integer is converted to a
+            ``keras.random.SeedGenerator`` and shared across all random draws in
+            the call. A ``SeedGenerator`` is passed through as-is, advancing its
+            state with each use. If ``None`` (default), the instance seed
+            generator is used.
+
+        Returns
+        -------
+        Tensor
+            Samples with shape ``batch_shape + (event_dim,)``.
+        """
         raise NotImplementedError
 
     def compute_output_shape(self, input_shape: Shape) -> Shape:

--- a/bayesflow/distributions/mixture.py
+++ b/bayesflow/distributions/mixture.py
@@ -1,14 +1,14 @@
+import math
 from collections.abc import Sequence
-
-import numpy as np
 
 import keras
 from keras import ops
 
+from bayesflow.distributions import Distribution
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils.decorators import allow_batch_size
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serializable, serialize
-from bayesflow.distributions import Distribution
 
 
 @serializable("bayesflow.distributions")
@@ -18,8 +18,9 @@ class Mixture(Distribution):
     def __init__(
         self,
         distributions: Sequence[Distribution],
-        mixture_logits: Sequence[float] = None,
+        mixture_logits: Sequence[float] | None = None,
         trainable_mixture: bool = False,
+        seed_generator: keras.random.SeedGenerator | None = None,
         **kwargs,
     ):
         """
@@ -35,6 +36,8 @@ class Mixture(Distribution):
         trainable_mixture : bool, optional
             Whether the mixture weights (`mixture_logits`) should be trainable.
             Default is `False`.
+        seed_generator : keras.random.SeedGenerator, optional
+            Seed generator for reproducible sampling. If ``None``, a new one is created.
         **kwargs
             Additional keyword arguments passed to the base `Distribution` class.
         """
@@ -49,15 +52,16 @@ class Mixture(Distribution):
             self.mixture_logits = ops.convert_to_tensor(mixture_logits)
 
         self.trainable_mixture = trainable_mixture
+        self.seed_generator = seed_generator or keras.random.SeedGenerator()
 
         self.dim = None
         self._mixture_logits = None
 
     @allow_batch_size
-    def sample(self, batch_shape: Shape) -> Tensor:
+    def sample(self, batch_shape: Shape, seed: int | keras.random.SeedGenerator | None = None) -> Tensor:
         """
         Draws samples from the mixture distribution by sampling a categorical index
-        for each entry in `batch_shape` according to the softmax of `mixture_logits`,
+        for each entry in `batch_shape` according to `mixture_logits`,
         then draws from the corresponding component distribution.
 
         Parameters
@@ -65,37 +69,36 @@ class Mixture(Distribution):
         batch_shape : Shape
             The desired sample batch shape (tuple of ints), not including the
             event dimension.
+        seed : int, keras.random.SeedGenerator, or None, optional
+            Seed for reproducible sampling. An integer is converted to a
+            ``keras.random.SeedGenerator`` and shared across all random draws in
+            the call. A ``SeedGenerator`` is passed through as-is, advancing its
+            state with each use. If ``None`` (default), the instance seed
+            generator is used.
 
         Returns
         -------
-        samples: Tensor
-            A tensor of shape `batch_shape + dims` containing samples drawn
-            from the mixture.
+        Tensor
+            Samples with shape ``batch_shape + (event_dim,)``.
         """
-        # Will use numpy until keras adds support for N-D categorical sampling
-        pvals = keras.ops.convert_to_numpy(keras.ops.softmax(self._mixture_logits))
-        cat_samples = np.random.multinomial(n=1, pvals=pvals, size=batch_shape)
-        cat_samples = cat_samples.argmax(axis=-1)
+        sg = resolve_seed(seed) or self.seed_generator
+        K = len(self.distributions)
+        total = math.prod(batch_shape)
 
-        # Prepare array to fill and dtype to infer
-        samples = np.zeros(batch_shape + (self.dim,))
-        dtype = None
+        # Sample component indices: (total,)
+        logits_broadcast = keras.ops.broadcast_to(keras.ops.expand_dims(self._mixture_logits, 0), (total, K))
+        cat_indices = keras.ops.squeeze(keras.random.categorical(logits_broadcast, num_samples=1, seed=sg), axis=-1)
 
-        # Fill in array with vectorized sampling per component
-        for i in range(len(self.distributions)):
-            dist_mask = cat_samples == i
-            dist_indices = np.where(dist_mask)
-            num_dist_samples = np.sum(dist_mask)
-            dist_samples = keras.ops.convert_to_numpy(self.distributions[i].sample(num_dist_samples))
+        # Sample from all components and select via one-hot mask (avoids dynamic shapes)
+        all_flat = keras.ops.stack(
+            [keras.ops.reshape(dist.sample(batch_shape, seed=sg), (total, self.dim)) for dist in self.distributions]
+        )
+        all_flat = keras.ops.transpose(all_flat, (1, 0, 2))
 
-            samples[dist_indices] = dist_samples
+        one_hot = keras.ops.cast(keras.ops.one_hot(cat_indices, K), all_flat.dtype)  # (total, K)
+        selected = keras.ops.sum(all_flat * one_hot[..., None], axis=1)  # (total, dim)
 
-            dtype = dtype or keras.ops.dtype(dist_samples)
-
-        # Convert to keras for compatibility
-        samples = keras.ops.convert_to_tensor(samples, dtype=dtype)
-
-        return samples
+        return keras.ops.reshape(selected, batch_shape + (self.dim,))
 
     def log_prob(self, samples: Tensor, *, normalize: bool = True) -> Tensor:
         """
@@ -147,6 +150,7 @@ class Mixture(Distribution):
             "distributions": self.distributions,
             "mixture_logits": self.mixture_logits,
             "trainable_mixture": self.trainable_mixture,
+            "seed_generator": self.seed_generator,
         }
 
         return base_config | serialize(config)

--- a/bayesflow/experimental/free_form_flow/free_form_flow.py
+++ b/bayesflow/experimental/free_form_flow/free_form_flow.py
@@ -140,6 +140,7 @@ class FreeFormFlow(InferenceNetwork):
     def _forward(
         self, x: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
     ) -> Tensor | tuple[Tensor, Tensor]:
+        kwargs.pop("seed", None)  # forward pass is deterministic; seed only used for base distribution
         if density:
             z, jac = jacobian(
                 lambda inp: self.encode(inp, conditions=conditions, training=training, **kwargs), x, return_output=True
@@ -155,6 +156,7 @@ class FreeFormFlow(InferenceNetwork):
     def _inverse(
         self, z: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
     ) -> Tensor | tuple[Tensor, Tensor]:
+        kwargs.pop("seed", None)  # inverse pass is deterministic; seed only used for base distribution
         if density:
             x, jac = jacobian(
                 lambda inp: self.decode(inp, conditions=conditions, training=training, **kwargs), z, return_output=True

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -12,6 +12,7 @@ from bayesflow.utils import (
     maybe_mask_tensor,
     random_mask,
     randomly_mask_along_axis,
+    resolve_seed,
     weighted_mean,
 )
 from bayesflow.utils.serialization import serializable, serialize
@@ -268,6 +269,7 @@ class ConsistencyModel(InferenceNetwork):
         x            : Tensor
             The approximate samples
         """
+        seed = resolve_seed(kwargs.pop("seed", None)) or self.seed_generator
         # Extract subnet masks from kwargs
         subnet_kwargs = self._collect_mask_kwargs(self._SUBNET_MASK_KEYS, kwargs)
         steps = int(kwargs.get("steps", self.s0 + 1))
@@ -298,7 +300,7 @@ class ConsistencyModel(InferenceNetwork):
         x = maybe_mask_tensor(x, mask=target_mask, replacement=targets_fixed)
 
         for n in range(1, steps):
-            noise = keras.random.normal(keras.ops.shape(x), dtype=keras.ops.dtype(x), seed=self.seed_generator)
+            noise = keras.random.normal(keras.ops.shape(x), dtype=keras.ops.dtype(x), seed=seed)
             x_n = x + keras.ops.sqrt(keras.ops.square(discretized_time[n]) - self.eps**2) * noise
             t = keras.ops.full_like(t, discretized_time[n])
             x_n = maybe_mask_tensor(x_n, mask=target_mask, replacement=targets_fixed)

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -14,6 +14,7 @@ from bayesflow.utils import (
     maybe_mask_tensor,
     random_mask,
     randomly_mask_along_axis,
+    resolve_seed,
     weighted_mean,
 )
 from bayesflow.utils.serialization import serializable, serialize
@@ -178,6 +179,7 @@ class StableConsistencyModel(InferenceNetwork):
         x            : Tensor
             The approximate samples
         """
+        seed = resolve_seed(kwargs.pop("seed", None)) or self.seed_generator
         # Extract subnet masks from kwargs
         subnet_kwargs = self._collect_mask_kwargs(self._SUBNET_MASK_KEYS, kwargs)
 
@@ -206,7 +208,7 @@ class StableConsistencyModel(InferenceNetwork):
         x = maybe_mask_tensor(x, mask=target_mask, replacement=targets_fixed)
 
         for n in range(1, steps):
-            noise = keras.random.normal(keras.ops.shape(x), dtype=keras.ops.dtype(x), seed=self.seed_generator)
+            noise = keras.random.normal(keras.ops.shape(x), dtype=keras.ops.dtype(x), seed=seed)
             x_n = ops.cos(t) * x + ops.sin(t) * noise
             t = keras.ops.full_like(t, discretized_time[n])
             x_n = maybe_mask_tensor(x_n, mask=target_mask, replacement=targets_fixed)

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -634,7 +634,7 @@ class DiffusionModel(InferenceNetwork):
     def _inverse(
         self, z: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
     ) -> Tensor | tuple[Tensor, Tensor]:
-        seed = resolve_seed(kwargs.pop("seed", None))
+        seed = resolve_seed(kwargs.pop("seed", None)) or self.seed_generator
         # Build integrate kwargs: hardcoded defaults -> instance config -> call-time overrides
         integrate_kwargs = {"start_time": 1.0, "stop_time": 0.0}
         integrate_kwargs |= self.integrate_kwargs
@@ -702,7 +702,7 @@ class DiffusionModel(InferenceNetwork):
                 score_fn=score_fn,
                 noise_schedule=self.noise_schedule,
                 state=state,
-                seed=seed or self.seed_generator,
+                seed=seed,
                 **integrate_kwargs,
             )
         else:

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -16,6 +16,7 @@ from bayesflow.utils import (
     maybe_mask_tensor,
     random_mask,
     randomly_mask_along_axis,
+    resolve_seed,
     weighted_mean,
     STOCHASTIC_METHODS,
     DETERMINISTIC_METHODS,
@@ -633,7 +634,8 @@ class DiffusionModel(InferenceNetwork):
     def _inverse(
         self, z: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
     ) -> Tensor | tuple[Tensor, Tensor]:
-        # Build integrate kwargs: hardcoded defaults → instance config → call-time overrides
+        seed = resolve_seed(kwargs.pop("seed", None))
+        # Build integrate kwargs: hardcoded defaults -> instance config -> call-time overrides
         integrate_kwargs = {"start_time": 1.0, "stop_time": 0.0}
         integrate_kwargs |= self.integrate_kwargs
         integrate_kwargs |= kwargs
@@ -700,7 +702,7 @@ class DiffusionModel(InferenceNetwork):
                 score_fn=score_fn,
                 noise_schedule=self.noise_schedule,
                 state=state,
-                seed=self.seed_generator,
+                seed=seed or self.seed_generator,
                 **integrate_kwargs,
             )
         else:

--- a/bayesflow/networks/inference/flow_matching/flow_matching.py
+++ b/bayesflow/networks/inference/flow_matching/flow_matching.py
@@ -254,7 +254,7 @@ class FlowMatching(InferenceNetwork):
     def _forward(
         self, x: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
     ) -> Tensor | tuple[Tensor, Tensor]:
-        # Build integrate kwargs: instance config → call-time overrides
+        # Build integrate kwargs: instance config -> call-time overrides
         integrate_kwargs = self.integrate_kwargs | kwargs
 
         # Apply user-provided target mask if available
@@ -296,7 +296,8 @@ class FlowMatching(InferenceNetwork):
     def _inverse(
         self, z: Tensor, conditions: Tensor = None, density: bool = False, training: bool = False, **kwargs
     ) -> Tensor | tuple[Tensor, Tensor]:
-        # Build integrate kwargs: instance config → call-time overrides
+        kwargs.pop("seed", None)  # ODE integration is deterministic; seed only used for base distribution
+        # Build integrate kwargs: instance config -> call-time overrides
         integrate_kwargs = self.integrate_kwargs | kwargs
 
         # Apply user-provided target mask if available

--- a/bayesflow/networks/inference/inference_network.py
+++ b/bayesflow/networks/inference/inference_network.py
@@ -23,11 +23,11 @@ class InferenceNetwork(keras.Layer):
     **at minimum** the following methods:
 
     ``_forward(x, conditions, density, training, **kwargs)``
-        Map data *x* → latent *z*.  When *density* is ``True`` the method must
+        Map data *x* -> latent *z*.  When *density* is ``True`` the method must
         return a tuple ``(z, log_prob)``; otherwise just *z*.
 
     ``_inverse(z, conditions, density, training, **kwargs)``
-        Map latent *z* → data *x*.  Same density convention as ``_forward``.
+        Map latent *z* -> data *x*.  Same density convention as ``_forward``.
 
     ``compute_metrics(x, conditions, sample_weight, stage)``
         Compute and return a ``dict[str, Tensor]`` of training metrics.  The dict

--- a/bayesflow/networks/inference/inference_network.py
+++ b/bayesflow/networks/inference/inference_network.py
@@ -5,6 +5,7 @@ import keras
 from bayesflow.types import Shape, Tensor
 from bayesflow.utils import layer_kwargs, find_distribution
 from bayesflow.utils.decorators import allow_batch_size
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import deserialize
 
 
@@ -110,9 +111,16 @@ class InferenceNetwork(keras.Layer):
         raise NotImplementedError
 
     @allow_batch_size
-    def sample(self, batch_shape: Shape, conditions: Tensor = None, **kwargs) -> Tensor:
-        samples = self.base_distribution.sample(batch_shape)
-        samples = self(samples, conditions=conditions, inverse=True, density=False, **kwargs)
+    def sample(
+        self,
+        batch_shape: Shape,
+        conditions: Tensor = None,
+        seed: int | keras.random.SeedGenerator | None = None,
+        **kwargs,
+    ) -> Tensor:
+        seed = resolve_seed(seed)
+        samples = self.base_distribution.sample(batch_shape, seed=seed)
+        samples = self(samples, conditions=conditions, inverse=True, density=False, seed=seed, **kwargs)
         return samples
 
     def log_prob(self, samples: Tensor, conditions: Tensor = None, **kwargs) -> Tensor:

--- a/bayesflow/networks/inference/scoring/scoring_rule_network.py
+++ b/bayesflow/networks/inference/scoring/scoring_rule_network.py
@@ -226,6 +226,7 @@ class ScoringRuleNetwork(keras.Layer):
         samples : dict[str, Tensor]
             Samples for every parametric scoring rule.
         """
+        seed_generator = resolve_seed(seed)
         if conditions is None:
             conditions = keras.ops.convert_to_tensor([[1.0]], dtype="float32")
 
@@ -244,7 +245,7 @@ class ScoringRuleNetwork(keras.Layer):
                         for k, v in parameters.items()
                     }
 
-                samples[score_key] = score.sample(batch_shape, seed=resolve_seed(seed), **parameters)
+                samples[score_key] = score.sample(batch_shape, seed=seed_generator, **parameters)
 
         return samples
 

--- a/bayesflow/networks/inference/scoring/scoring_rule_network.py
+++ b/bayesflow/networks/inference/scoring/scoring_rule_network.py
@@ -1,6 +1,7 @@
 import keras
 
 from bayesflow.utils import model_kwargs, find_network
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import deserialize, serializable, serialize
 from bayesflow.types import Shape, Tensor
 from .scoring_rules import ScoringRule, ParametricDistributionScore
@@ -194,7 +195,9 @@ class ScoringRuleNetwork(keras.Layer):
         return metrics | {"loss": neg_score}
 
     @allow_batch_size
-    def sample(self, batch_shape: Shape, conditions: Tensor | None = None) -> dict[str, Tensor]:
+    def sample(
+        self, batch_shape: Shape, conditions: Tensor | None = None, seed: int | keras.random.SeedGenerator | None = None
+    ) -> dict[str, Tensor]:
         """
         Draw one sample per parameter set from each parametric scoring rule.
 
@@ -209,6 +212,14 @@ class ScoringRuleNetwork(keras.Layer):
             - unconditional: ``(num_samples,)`` — single parameter set broadcast.
         conditions : Tensor or None, default None
             Optional inference conditions. If not given, unconditional samples are returned.
+        seed : int, keras.random.SeedGenerator, or None, optional
+            Seed for reproducible sampling. An integer is converted to a
+            ``keras.random.SeedGenerator`` and shared across all random draws in
+            the call. A ``SeedGenerator`` is passed through as-is, advancing its
+            state with each use. If ``None`` (default), the instance seed
+            generator is used.
+
+
 
         Returns
         -------
@@ -233,7 +244,7 @@ class ScoringRuleNetwork(keras.Layer):
                         for k, v in parameters.items()
                     }
 
-                samples[score_key] = score.sample(batch_shape, **parameters)
+                samples[score_key] = score.sample(batch_shape, seed=resolve_seed(seed), **parameters)
 
         return samples
 

--- a/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
@@ -195,9 +195,9 @@ class MixtureScore(ParametricDistributionScore):
         Parameters
         ----------
         batch_shape : Shape
-            A tuple (batch_size, num_samples).
+            A tuple (batch_size * num_samples,).
         seed : int, keras.random.SeedGenerator, or None, optional
-            Seed for reproducible sampling, shared across component index selection and all component samples.
+            Seed or shared seed generator for reproducible sampling.
         **estimates : dict[str, Tensor]
             Flat dict containing mixture logits and all component parameter heads.
 
@@ -206,33 +206,30 @@ class MixtureScore(ParametricDistributionScore):
         Tensor
             Samples with shape (batch_size, num_samples, ...).
         """
-        if len(batch_shape) != 2:
-            raise ValueError("`batch_shape` must be a tuple (batch_size, num_samples).")
+        assert len(batch_shape) == 1  # approximator.helpers.Sampler makes sure that batch_shape is flat
+        batch_size = batch_shape[0]
 
-        batch_size, num_samples = batch_shape
         logits = estimates[self.weight_head]  # (batch_size, K) typically
         probs = keras.ops.softmax(logits / self.temperature, axis=-1)  # (batch_size, K)
 
         # Sample component indices via inverse-CDF on uniform draws
-        sg = resolve_seed(seed)
-        u = keras.random.uniform((batch_size, num_samples, 1), dtype=probs.dtype, seed=sg)
-        cdf = keras.ops.cumsum(probs, axis=-1)[:, None, :]  # (B, 1, K)
-        cdf = keras.ops.broadcast_to(cdf, (batch_size, num_samples, self.K))  # (B, S, K)
-        idx = keras.ops.argmax(keras.ops.cast(u <= cdf, "int32"), axis=-1)  # (B, S)
+        seed_generator = resolve_seed(seed)
+        u = keras.random.uniform((batch_size, 1), dtype=probs.dtype, seed=seed_generator)
+        cdf = keras.ops.cumsum(probs, axis=-1)
+        idx = keras.ops.argmax(keras.ops.cast(u <= cdf, "int32"), axis=-1)  # (B,)
 
         # Sample from all components and select via one-hot mask
         comp_samples = []
         for c in self.component_names:
             c_est = self._component_estimates(estimates, c)
-            c_est = {k: keras.ops.repeat(keras.ops.expand_dims(v, 1), num_samples, axis=1) for k, v in c_est.items()}
-            s = self.components[c].sample((batch_size, num_samples), seed=sg, **c_est)
+            s = self.components[c].sample((batch_size,), seed=seed_generator, **c_est)
             comp_samples.append(s)
 
-        stacked = keras.ops.stack(comp_samples, axis=2)  # (B, S, K, ...)
-        mask = keras.ops.one_hot(idx, self.K, dtype=stacked.dtype)  # (B, S, K)
+        stacked = keras.ops.stack(comp_samples, axis=0)  # (K, B, ...)
+        mask = keras.ops.one_hot(idx, self.K, axis=0, dtype=stacked.dtype)  # (K, B)
 
-        # Expand mask to match stacked rank: (B, S, K, 1, 1, ...)
+        # Expand mask to match stacked rank: (K, B, 1, 1, ...)
         while mask.ndim < stacked.ndim:
             mask = mask[..., None]
 
-        return keras.ops.sum(stacked * mask, axis=2)
+        return keras.ops.sum(stacked * mask, axis=0)

--- a/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
@@ -206,7 +206,9 @@ class MixtureScore(ParametricDistributionScore):
         Tensor
             Samples with shape (batch_size, num_samples, ...).
         """
-        assert len(batch_shape) == 1  # approximator.helpers.Sampler makes sure that batch_shape is flat
+        assert len(batch_shape) == 1, (
+            f"Got unexpected {batch_shape=}. Usually approximator.helpers.Sampler makes sure that batch_shape is flat"
+        )
         batch_size = batch_shape[0]
 
         logits = estimates[self.weight_head]  # (batch_size, K) typically

--- a/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
@@ -1,6 +1,7 @@
 import keras
 
 from bayesflow.types import Shape, Tensor
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serializable, serialize, deserialize
 
 from .parametric_distribution_score import ParametricDistributionScore
@@ -185,7 +186,9 @@ class MixtureScore(ParametricDistributionScore):
 
         return keras.ops.logsumexp(log_w + logps, axis=-1)
 
-    def sample(self, batch_shape: Shape, **estimates: Tensor) -> Tensor:
+    def sample(
+        self, batch_shape: Shape, *, seed: int | keras.random.SeedGenerator | None = None, **estimates: Tensor
+    ) -> Tensor:
         """
         Draw samples from the mixture.
 
@@ -193,6 +196,8 @@ class MixtureScore(ParametricDistributionScore):
         ----------
         batch_shape : Shape
             A tuple (batch_size, num_samples).
+        seed : int, keras.random.SeedGenerator, or None, optional
+            Seed for reproducible sampling, shared across component index selection and all component samples.
         **estimates : dict[str, Tensor]
             Flat dict containing mixture logits and all component parameter heads.
 
@@ -209,7 +214,8 @@ class MixtureScore(ParametricDistributionScore):
         probs = keras.ops.softmax(logits / self.temperature, axis=-1)  # (batch_size, K)
 
         # Sample component indices via inverse-CDF on uniform draws
-        u = keras.random.uniform((batch_size, num_samples, 1), dtype=probs.dtype)
+        sg = resolve_seed(seed)
+        u = keras.random.uniform((batch_size, num_samples, 1), dtype=probs.dtype, seed=sg)
         cdf = keras.ops.cumsum(probs, axis=-1)[:, None, :]  # (B, 1, K)
         cdf = keras.ops.broadcast_to(cdf, (batch_size, num_samples, self.K))  # (B, S, K)
         idx = keras.ops.argmax(keras.ops.cast(u <= cdf, "int32"), axis=-1)  # (B, S)
@@ -219,7 +225,7 @@ class MixtureScore(ParametricDistributionScore):
         for c in self.component_names:
             c_est = self._component_estimates(estimates, c)
             c_est = {k: keras.ops.repeat(keras.ops.expand_dims(v, 1), num_samples, axis=1) for k, v in c_est.items()}
-            s = self.components[c].sample((batch_size, num_samples), **c_est)
+            s = self.components[c].sample((batch_size, num_samples), seed=sg, **c_est)
             comp_samples.append(s)
 
         stacked = keras.ops.stack(comp_samples, axis=2)  # (B, S, K, ...)

--- a/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mixture_score.py
@@ -187,7 +187,7 @@ class MixtureScore(ParametricDistributionScore):
         return keras.ops.logsumexp(log_w + logps, axis=-1)
 
     def sample(
-        self, batch_shape: Shape, *, seed: int | keras.random.SeedGenerator | None = None, **estimates: Tensor
+        self, batch_shape: Shape, seed: int | keras.random.SeedGenerator | None = None, **estimates: Tensor
     ) -> Tensor:
         """
         Draw samples from the mixture.

--- a/bayesflow/networks/inference/scoring/scoring_rules/mv_normal_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mv_normal_score.py
@@ -4,6 +4,7 @@ import keras
 
 from bayesflow.types import Shape, Tensor
 from bayesflow.links import CholeskyFactor
+from bayesflow.utils.keras_utils import resolve_seed
 from bayesflow.utils.serialization import serializable
 
 from .parametric_distribution_score import ParametricDistributionScore
@@ -98,7 +99,14 @@ class MvNormalScore(ParametricDistributionScore):
 
         return log_prob
 
-    def sample(self, batch_shape: Shape, mean: Tensor, precision_cholesky_factor: Tensor) -> Tensor:
+    def sample(
+        self,
+        batch_shape: Shape,
+        *,
+        mean: Tensor,
+        precision_cholesky_factor: Tensor,
+        seed: int | keras.random.SeedGenerator | None = None,
+    ) -> Tensor:
         """
         Generate samples from a multivariate Gaussian distribution.
 
@@ -117,6 +125,8 @@ class MvNormalScore(ParametricDistributionScore):
             A tensor representing the lower-triangular Cholesky factor of the precision matrix
             of the multivariate Gaussian distribution.
             Shape: ``(..., D, D)``.
+        seed : int, keras.random.SeedGenerator, or None, optional
+            Seed for reproducible sampling.
 
         Returns
         -------
@@ -124,7 +134,7 @@ class MvNormalScore(ParametricDistributionScore):
             Samples with the same shape as ``mean``.
         """
         covariance_cholesky_factor = keras.ops.inv(precision_cholesky_factor)
-        normal_samples = keras.random.normal(keras.ops.shape(mean))
+        normal_samples = keras.random.normal(keras.ops.shape(mean), seed=resolve_seed(seed))
         scaled_normal = keras.ops.einsum("...ij,...j->...i", covariance_cholesky_factor, normal_samples)
         samples = mean + scaled_normal
         return samples

--- a/bayesflow/networks/inference/scoring/scoring_rules/mv_normal_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/mv_normal_score.py
@@ -102,7 +102,6 @@ class MvNormalScore(ParametricDistributionScore):
     def sample(
         self,
         batch_shape: Shape,
-        *,
         mean: Tensor,
         precision_cholesky_factor: Tensor,
         seed: int | keras.random.SeedGenerator | None = None,

--- a/bayesflow/networks/inference/scoring/scoring_rules/parametric_distribution_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/parametric_distribution_score.py
@@ -19,7 +19,7 @@ class ParametricDistributionScore(ScoringRule):
     def log_prob(self, *args, **kwargs):
         raise NotImplementedError
 
-    def sample(self, batch_shape, *, seed=None, **kwargs):
+    def sample(self, batch_shape, seed=None, **kwargs):
         raise NotImplementedError
 
     def score(self, estimates: dict[str, Tensor], targets: Tensor, weights: Tensor = None) -> Tensor:

--- a/bayesflow/networks/inference/scoring/scoring_rules/parametric_distribution_score.py
+++ b/bayesflow/networks/inference/scoring/scoring_rules/parametric_distribution_score.py
@@ -19,7 +19,7 @@ class ParametricDistributionScore(ScoringRule):
     def log_prob(self, *args, **kwargs):
         raise NotImplementedError
 
-    def sample(self, *args, **kwargs):
+    def sample(self, batch_shape, *, seed=None, **kwargs):
         raise NotImplementedError
 
     def score(self, estimates: dict[str, Tensor], targets: Tensor, weights: Tensor = None) -> Tensor:

--- a/bayesflow/utils/__init__.py
+++ b/bayesflow/utils/__init__.py
@@ -2,6 +2,8 @@
 A collection of utility functions, mostly used for internal purposes.
 """
 
+from .keras_utils import resolve_seed
+
 from . import (
     keras_utils,
     logging,

--- a/bayesflow/utils/keras_utils.py
+++ b/bayesflow/utils/keras_utils.py
@@ -4,6 +4,13 @@ import numpy as np
 from bayesflow.types import Tensor
 
 
+def resolve_seed(seed):
+    """Convert an integer seed to a SeedGenerator; pass a SeedGenerator or None through unchanged."""
+    if isinstance(seed, int):
+        return keras.random.SeedGenerator(seed)
+    return seed
+
+
 def inverse_shifted_softplus(x: Tensor, shift: float = np.log(np.e - 1), beta: float = 1.0, threshold: float = 20.0):
     """Inverse of the shifted softplus function."""
     return inverse_softplus(x, beta=beta, threshold=threshold) - shift

--- a/bayesflow/utils/keras_utils.py
+++ b/bayesflow/utils/keras_utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 import keras
 import numpy as np
 
@@ -9,6 +10,18 @@ def resolve_seed(seed):
     if isinstance(seed, int):
         return keras.random.SeedGenerator(seed)
     return seed
+
+
+def keras_multinomial(
+    num_samples: int, probs: Sequence[float], *, seed: int | keras.random.SeedGenerator | None = None
+):
+    K = len(probs)
+    logits_broadcast = keras.ops.broadcast_to(keras.ops.expand_dims(keras.ops.log(probs), axis=0), (num_samples, K))
+    cat_indices = keras.ops.squeeze(keras.random.categorical(logits_broadcast, num_samples=1, seed=seed), axis=-1)
+    one_hot = keras.ops.one_hot(cat_indices, K)
+    counts = keras.ops.sum(one_hot, axis=0)
+
+    return counts
 
 
 def inverse_shifted_softplus(x: Tensor, shift: float = np.log(np.e - 1), beta: float = 1.0, threshold: float = 20.0):

--- a/bayesflow/utils/keras_utils.py
+++ b/bayesflow/utils/keras_utils.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 import keras
 import numpy as np
 
@@ -10,18 +9,6 @@ def resolve_seed(seed):
     if isinstance(seed, int):
         return keras.random.SeedGenerator(seed)
     return seed
-
-
-def keras_multinomial(
-    num_samples: int, probs: Sequence[float], *, seed: int | keras.random.SeedGenerator | None = None
-):
-    K = len(probs)
-    logits_broadcast = keras.ops.broadcast_to(keras.ops.expand_dims(keras.ops.log(probs), axis=0), (num_samples, K))
-    cat_indices = keras.ops.squeeze(keras.random.categorical(logits_broadcast, num_samples=1, seed=seed), axis=-1)
-    one_hot = keras.ops.one_hot(cat_indices, K)
-    counts = keras.ops.sum(one_hot, axis=0)
-
-    return counts
 
 
 def inverse_shifted_softplus(x: Tensor, shift: float = np.log(np.e - 1), beta: float = 1.0, threshold: float = 20.0):

--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -273,6 +273,7 @@ class BasicWorkflow(Workflow):
         split: bool = False,
         batch_size: int | None = None,
         sample_shape: Literal["infer"] | Tuple[int] | int = "infer",
+        seed: int | keras.random.SeedGenerator | None = None,
         **kwargs,
     ) -> dict[str, np.ndarray]:
         """
@@ -300,6 +301,10 @@ class BasicWorkflow(Workflow):
             dimensions. For example, if the final `inference_conditions` have shape `(batch_size, time, channels)`,
             then `sample_shape` is inferred as `(time,)`, and the generated samples will have shape
             `(num_conditions, num_samples, time, target_dim)`.
+        seed : int, keras.random.SeedGenerator, or None, optional
+            Seed for reproducible sampling. An integer is converted to a ``keras.random.SeedGenerator``
+            and shared across all stochastic operations in the call. A ``SeedGenerator`` is passed through
+            as-is. If ``None`` (default), each component uses its own instance seed generator or a global one.
         **kwargs : dict | str, optional
             Additional keyword arguments passed to the approximator's sampling function.
 
@@ -316,6 +321,7 @@ class BasicWorkflow(Workflow):
             split=split,
             batch_size=batch_size,
             sample_shape=sample_shape,
+            seed=seed,
             **kwargs,
         )
         elapsed = time.perf_counter() - start_time

--- a/bayesflow/workflows/basic_workflow.py
+++ b/bayesflow/workflows/basic_workflow.py
@@ -304,7 +304,7 @@ class BasicWorkflow(Workflow):
         seed : int, keras.random.SeedGenerator, or None, optional
             Seed for reproducible sampling. An integer is converted to a ``keras.random.SeedGenerator``
             and shared across all stochastic operations in the call. A ``SeedGenerator`` is passed through
-            as-is. If ``None`` (default), each component uses its own instance seed generator or a global one.
+            as-is. If ``None`` (default), each component uses its own instance seed generator.
         **kwargs : dict | str, optional
             Additional keyword arguments passed to the approximator's sampling function.
 

--- a/tests/test_approximators/conftest.py
+++ b/tests/test_approximators/conftest.py
@@ -138,10 +138,18 @@ def point_approximator_without_parametric_score(adapter, summary_network):
 
 @pytest.fixture()
 def ensemble_approximator_continuous_and_point(continuous_approximator, point_approximator_without_parametric_score):
+    import keras
     from bayesflow import EnsembleApproximator
 
+    continuous_approximator_clone = keras.models.clone_model(continuous_approximator)
+    # adapters must be shared among ensemble members
+    continuous_approximator_clone.adapter = continuous_approximator.adapter
     return EnsembleApproximator(
-        dict(cont_approx=continuous_approximator, point_approx=point_approximator_without_parametric_score)
+        dict(
+            cont_approx=continuous_approximator,
+            cont_approx_2=continuous_approximator_clone,
+            point_approx=point_approximator_without_parametric_score,
+        )
     )
 
 

--- a/tests/test_approximators/test_ensemble_approximator/test_sample.py
+++ b/tests/test_approximators/test_ensemble_approximator/test_sample.py
@@ -20,3 +20,16 @@ def test_approximator_sample(ensemble_approximator, simulator, batch_size, adapt
 
     for samples_value in samples.values():
         assert isinstance(samples_value, np.ndarray)
+
+    samples_seed42_1 = ensemble_approximator.sample(num_samples=2, conditions=data, seed=42)
+    samples_seed42_2 = ensemble_approximator.sample(num_samples=2, conditions=data, seed=42)
+
+    for key in samples.keys():
+        assert np.allclose(
+            samples_seed42_1[key],
+            samples_seed42_2[key],
+        ), "samples differ for identical seed"
+        assert not np.allclose(
+            samples_seed42_1[key],
+            samples[key],
+        ), "samples do not differ in unseeded case"

--- a/tests/test_approximators/test_ensemble_approximator/test_sample.py
+++ b/tests/test_approximators/test_ensemble_approximator/test_sample.py
@@ -1,3 +1,4 @@
+import pytest
 import keras
 import numpy as np
 from tests.utils import check_combination_simulator_adapter
@@ -25,11 +26,13 @@ def test_approximator_sample(ensemble_approximator, simulator, batch_size, adapt
     samples_seed42_2 = ensemble_approximator.sample(num_samples=2, conditions=data, seed=42)
 
     for key in samples.keys():
-        assert np.allclose(
+        np.testing.assert_allclose(
             samples_seed42_1[key],
             samples_seed42_2[key],
-        ), "samples differ for identical seed"
-        assert not np.allclose(
-            samples_seed42_1[key],
-            samples[key],
-        ), "samples do not differ in unseeded case"
+            err_msg=f"{key}: samples differ for identical seed",
+        )
+        with pytest.raises(AssertionError):
+            np.testing.assert_allclose(
+                samples_seed42_1[key],
+                samples[key],
+            )

--- a/tests/test_approximators/test_scoring_rule_approximator/conftest.py
+++ b/tests/test_approximators/test_scoring_rule_approximator/conftest.py
@@ -4,13 +4,14 @@ import pytest
 @pytest.fixture()
 def scoring_rule_inference_network():
     from bayesflow.networks import ScoringRuleNetwork
-    from bayesflow.scoring_rules import NormedDifferenceScore, QuantileScore, MvNormalScore
+    from bayesflow.scoring_rules import NormedDifferenceScore, QuantileScore, MvNormalScore, MixtureScore
 
     return ScoringRuleNetwork(
         scoring_rules=dict(
             mean=NormedDifferenceScore(k=2),
             quantiles=QuantileScore(q=[0.1, 0.5, 0.9]),
             mvn=MvNormalScore(),
+            mix=MixtureScore(mvn_c1=MvNormalScore(), mvn_c2=MvNormalScore()),
         ),
         subnet="mlp",
         subnet_kwargs=dict(widths=(8, 8)),

--- a/tests/test_approximators/test_scoring_rule_approximator/test_sample.py
+++ b/tests/test_approximators/test_scoring_rule_approximator/test_sample.py
@@ -52,11 +52,13 @@ def test_sample(scoring_rule_approximator_any, simulator, batch_size, num_sample
     samples_seed42_2 = scoring_rule_approximator_any.sample(num_samples=num_samples, conditions=data, seed=42)
 
     for key in samples_merged.keys():
-        assert np.allclose(
+        np.testing.assert_allclose(
             samples_seed42_1[key],
             samples_seed42_2[key],
-        ), f"{key}: samples differ for identical seed"
-        assert not np.allclose(
-            samples_seed42_1[key],
-            samples_merged[key],
-        ), f"{key}: samples do not differ in unseeded case"
+            err_msg=f"{key}: samples differ for identical seed",
+        )
+        with pytest.raises(AssertionError):
+            np.testing.assert_allclose(
+                samples_seed42_1[key],
+                samples_merged[key],
+            )

--- a/tests/test_approximators/test_scoring_rule_approximator/test_sample.py
+++ b/tests/test_approximators/test_scoring_rule_approximator/test_sample.py
@@ -47,3 +47,16 @@ def test_sample(scoring_rule_approximator_any, simulator, batch_size, num_sample
         for variable, variable_estimates in samples_separate.items():
             assert isinstance(variable_estimates, np.ndarray)
             assert variable_estimates.shape[:-1] == (batch_size, num_samples)
+
+    samples_seed42_1 = scoring_rule_approximator_any.sample(num_samples=num_samples, conditions=data, seed=42)
+    samples_seed42_2 = scoring_rule_approximator_any.sample(num_samples=num_samples, conditions=data, seed=42)
+
+    for key in samples_merged.keys():
+        assert np.allclose(
+            samples_seed42_1[key],
+            samples_seed42_2[key],
+        ), f"{key}: samples differ for identical seed"
+        assert not np.allclose(
+            samples_seed42_1[key],
+            samples_merged[key],
+        ), f"{key}: samples do not differ in unseeded case"

--- a/tests/test_networks/conftest.py
+++ b/tests/test_networks/conftest.py
@@ -54,6 +54,16 @@ def consistency_model():
 
 
 @pytest.fixture()
+def stable_consistency_model():
+    from bayesflow.networks import StableConsistencyModel
+
+    return StableConsistencyModel(
+        total_steps=100,
+        subnet_kwargs=dict(widths=[8, 8]),
+    )
+
+
+@pytest.fixture()
 def affine_coupling_flow():
     from bayesflow.networks import CouplingFlow
 
@@ -121,6 +131,7 @@ def typical_scoring_rule_network_subnet():
         "flow_matching",
         "free_form_flow",
         "consistency_model",
+        "stable_consistency_model",
         pytest.param("diffusion_model_edm_F"),
         pytest.param("diffusion_model_cosine_velocity", marks=pytest.mark.slow),
         pytest.param("diffusion_model_cosine_noise", marks=pytest.mark.slow),
@@ -151,6 +162,7 @@ def inference_network_subnet(request):
         "flow_matching",
         "free_form_flow",
         "consistency_model",
+        "stable_consistency_model",
         pytest.param("diffusion_model_edm_F"),
         pytest.param("diffusion_model_cosine_velocity", marks=pytest.mark.slow),
     ],

--- a/tests/test_networks/conftest.py
+++ b/tests/test_networks/conftest.py
@@ -81,7 +81,7 @@ def free_form_flow():
 @pytest.fixture()
 def typical_scoring_rule_network():
     from bayesflow.networks import ScoringRuleNetwork
-    from bayesflow.scoring_rules import MeanScore, MedianScore, QuantileScore, MvNormalScore
+    from bayesflow.scoring_rules import MeanScore, MedianScore, QuantileScore, MvNormalScore, MixtureScore
 
     return ScoringRuleNetwork(
         scoring_rules=dict(
@@ -89,6 +89,7 @@ def typical_scoring_rule_network():
             median=MedianScore(),
             quantiles=QuantileScore([0.1, 0.2, 0.5, 0.65]),
             mvn=MvNormalScore(),
+            mix=MixtureScore(mvn_c1=MvNormalScore(), mvn_c2=MvNormalScore()),
         )
     )
 
@@ -96,7 +97,7 @@ def typical_scoring_rule_network():
 @pytest.fixture()
 def typical_scoring_rule_network_subnet():
     from bayesflow.networks import ScoringRuleNetwork
-    from bayesflow.scoring_rules import MeanScore, MedianScore, QuantileScore, MvNormalScore
+    from bayesflow.scoring_rules import MeanScore, MedianScore, QuantileScore, MvNormalScore, MixtureScore
 
     subnet = MLP([16, 8])
 
@@ -106,6 +107,7 @@ def typical_scoring_rule_network_subnet():
             median=MedianScore(subnets=dict(value=subnet)),
             quantiles=QuantileScore(subnets=dict(value=subnet)),
             mvn=MvNormalScore(subnets=dict(mean=subnet, covariance=subnet)),
+            mix=MixtureScore(mvn_c1=MvNormalScore(), mvn_c2=MvNormalScore(), subnets=dict(mixture_logits=subnet)),
         ),
         subnet=subnet,
     )

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -23,7 +23,7 @@ def test_build(inference_network, random_samples, random_conditions):
 
 
 def test_variable_batch_size(inference_network, random_samples, random_conditions):
-    from bayesflow.networks import ScoringRuleNetwork, ConsistencyModel
+    from bayesflow.networks import ScoringRuleNetwork, ConsistencyModel, StableConsistencyModel
 
     # build with one batch size
     samples_shape = keras.ops.shape(random_samples)
@@ -39,7 +39,7 @@ def test_variable_batch_size(inference_network, random_samples, random_condition
         else:
             new_conditions = keras.ops.zeros((bs,) + keras.ops.shape(random_conditions)[1:])
 
-        if isinstance(inference_network, ConsistencyModel):
+        if isinstance(inference_network, (ConsistencyModel, StableConsistencyModel)):
             # consistency models don't implement .forward
             with pytest.raises(NotImplementedError):
                 inference_network(new_input, conditions=new_conditions)

--- a/tests/test_networks/test_sample.py
+++ b/tests/test_networks/test_sample.py
@@ -22,11 +22,11 @@ def test_sample_seed_determinism(inference_network):
         if not has_distribution:
             pytest.skip("This ScoringRuleNetwork has no parametric distribution scores to sample from")
 
-    from bayesflow.networks import ConsistencyModel, DiffusionModel, FlowMatching
+    from bayesflow.networks import ConsistencyModel, StableConsistencyModel, DiffusionModel, FlowMatching
 
     sample_kwargs = dict(conditions=keras.random.normal(conditions_shape))
     # Pass steps=2 to iterative networks to keep the test fast
-    if isinstance(inference_network, (ConsistencyModel, DiffusionModel, FlowMatching)):
+    if isinstance(inference_network, (ConsistencyModel, StableConsistencyModel, DiffusionModel, FlowMatching)):
         sample_kwargs["steps"] = 2
 
     samples_seed42_1 = inference_network.sample(batch_shape, seed=42, **sample_kwargs)

--- a/tests/test_networks/test_sample.py
+++ b/tests/test_networks/test_sample.py
@@ -1,0 +1,46 @@
+import keras
+import numpy as np
+import pytest
+
+
+def test_sample_seed_determinism(inference_network):
+    from bayesflow.networks import ScoringRuleNetwork
+
+    xz_shape = (2, 3)
+    conditions_shape = (2, 8)
+
+    inference_network.build(xz_shape, conditions_shape=conditions_shape)
+
+    batch_shape = (xz_shape[0],)
+
+    if isinstance(inference_network, ScoringRuleNetwork):
+        from bayesflow.scoring_rules import ParametricDistributionScore
+
+        has_distribution = any(
+            isinstance(score, ParametricDistributionScore) for score in inference_network.scoring_rules.values()
+        )
+        if not has_distribution:
+            pytest.skip("This ScoringRuleNetwork has no parametric distribution scores to sample from")
+
+    from bayesflow.networks import ConsistencyModel, DiffusionModel, FlowMatching
+
+    sample_kwargs = dict(conditions=keras.random.normal(conditions_shape))
+    # Pass steps=2 to iterative networks to keep the test fast
+    if isinstance(inference_network, (ConsistencyModel, DiffusionModel, FlowMatching)):
+        sample_kwargs["steps"] = 2
+
+    samples_seed42_1 = inference_network.sample(batch_shape, seed=42, **sample_kwargs)
+    samples_seed42_2 = inference_network.sample(batch_shape, seed=42, **sample_kwargs)
+    samples_no_seed = inference_network.sample(batch_shape, **sample_kwargs)
+
+    # deal with both return types dict and Tensor of sample methods (ScoringRuleNetwork returns dict)
+    def leaves(x):
+        return keras.tree.flatten(x)
+
+    for s1, s2, s_unseeded in zip(leaves(samples_seed42_1), leaves(samples_seed42_2), leaves(samples_no_seed)):
+        arr1 = keras.ops.convert_to_numpy(s1)
+        arr2 = keras.ops.convert_to_numpy(s2)
+        arr_unseeded = keras.ops.convert_to_numpy(s_unseeded)
+
+        assert np.allclose(arr1, arr2), f"samples differ for identical seed ({inference_network})"
+        assert not np.allclose(arr1, arr_unseeded), f"seeded and unseeded samples are identical ({inference_network})"

--- a/tests/test_networks/test_sample.py
+++ b/tests/test_networks/test_sample.py
@@ -42,5 +42,13 @@ def test_sample_seed_determinism(inference_network):
         arr2 = keras.ops.convert_to_numpy(s2)
         arr_unseeded = keras.ops.convert_to_numpy(s_unseeded)
 
-        assert np.allclose(arr1, arr2), f"samples differ for identical seed ({inference_network})"
-        assert not np.allclose(arr1, arr_unseeded), f"seeded and unseeded samples are identical ({inference_network})"
+        np.testing.assert_allclose(
+            arr1,
+            arr2,
+            err_msg=f"{inference_network}: samples differ for identical seed",
+        )
+        with pytest.raises(AssertionError):
+            np.testing.assert_allclose(
+                arr1,
+                arr_unseeded,
+            )

--- a/tests/test_scoring_rules/test_scoring_rules.py
+++ b/tests/test_scoring_rules/test_scoring_rules.py
@@ -61,7 +61,7 @@ def test_mixture_score_constructor_validation():
 
 
 def test_mixture_score_sample_shape(mixture_of_multivariate_normal_scores):
-    batch_size, num_samples, dim = 4, 10, 3
+    batch_size, dim = 4, 3
     mix = mixture_of_multivariate_normal_scores
     eye = keras.ops.broadcast_to(keras.ops.eye(dim)[None], (batch_size, dim, dim))
     estimates = {
@@ -72,9 +72,9 @@ def test_mixture_score_sample_shape(mixture_of_multivariate_normal_scores):
         "mvn2__precision_cholesky_factor": eye,
     }
 
-    samples = mix.sample((batch_size, num_samples), **estimates)
+    samples = mix.sample((batch_size,), **estimates)
 
-    assert samples.shape == (batch_size, num_samples, dim)
+    assert samples.shape == (batch_size, dim)
 
 
 def test_mixture_score_set_temperature(mixture_of_multivariate_normal_scores):


### PR DESCRIPTION
This PR addresses issue #666.

Essentially, it extends the seed argument that already exists in all `keras.random` functions (like https://github.com/keras-team/keras/blob/v3.14.0/keras/src/random/random.py#L5) all the way up to the `workflow.sample` method in a way that makes sure that randomness in all different components of high-level objects (like workflow) stays uncorrelated.

Moreover: ports `distribution.Mixture` randomness from numpy to keras, adds a `keras_utils.keras_multinomial` convenience function and fixes a bug regarding correct handling of `batch_shape` between `ScoringRuleApproximator` and `MixtureScore`.

To confirm that samples for the same seed are identical, corresponding integration tests with 

* an `EnsembleApproximator` with a CouplingFlow and a DiffusionModel approximator and 
* a `ScoringRuleApproximator` with both a standalone `MvNormalScore` and a `MixtureScore` of two `MvNormalScore`s 

are passing.

to do:

* [x] The tests included in the initial commits are still "work in progress" and should be improved to run faster (especially `DiffusionModel` can be wasteful to sample) and integrate well with the existing fixtures. (The `DiffusionModel` tests were only performed locally at this point)
* [x] `workflow.sample`