### PR TITLE
Allow Ordered/OrderedQuantiles links to treat axis shorter than 3

### DIFF
--- a/bayesflow/links/ordered.py
+++ b/bayesflow/links/ordered.py
@@ -24,6 +24,12 @@ class Ordered(keras.Layer):
     def build(self, input_shape):
         super().build(input_shape)
 
+        axis_size = input_shape[self.axis]
+        if not (0 <= self.anchor_index < axis_size):
+            raise ValueError(
+                f"anchor_index={self.anchor_index} is out of bounds for axis {self.axis} with size {axis_size}."
+            )
+
         self.group_indices = dict(
             below=list(range(0, self.anchor_index)),
             above=list(range(self.anchor_index + 1, input_shape[self.axis])),

--- a/bayesflow/links/ordered.py
+++ b/bayesflow/links/ordered.py
@@ -24,9 +24,6 @@ class Ordered(keras.Layer):
     def build(self, input_shape):
         super().build(input_shape)
 
-        if self.anchor_index % input_shape[self.axis] == 0 or self.anchor_index == -1:
-            raise RuntimeError("Anchor should not be first or last index.")
-
         self.group_indices = dict(
             below=list(range(0, self.anchor_index)),
             above=list(range(self.anchor_index + 1, input_shape[self.axis])),
@@ -34,21 +31,29 @@ class Ordered(keras.Layer):
 
     def call(self, inputs):
         # Divide in anchor, below and above
-        below_inputs = keras.ops.take(inputs, self.group_indices["below"], axis=self.axis)
         anchor_input = keras.ops.take(inputs, self.anchor_index, axis=self.axis)
         anchor_input = keras.ops.expand_dims(anchor_input, axis=self.axis)
-        above_inputs = keras.ops.take(inputs, self.group_indices["above"], axis=self.axis)
 
-        # Apply softplus for positivity and cumulate to ensure ordered quantiles
-        below = keras.activations.softplus(below_inputs)
-        above = keras.activations.softplus(above_inputs)
+        parts = []
 
-        below = anchor_input - keras.ops.flip(keras.ops.cumsum(below, axis=self.axis), self.axis)
-        above = anchor_input + keras.ops.cumsum(above, axis=self.axis)
+        if self.group_indices["below"]:
+            below_inputs = keras.ops.take(inputs, self.group_indices["below"], axis=self.axis)
+            below = keras.activations.softplus(below_inputs)
+            below = anchor_input - keras.ops.flip(keras.ops.cumsum(below, axis=self.axis), self.axis)
+            parts.append(below)
+
+        parts.append(anchor_input)
+
+        if self.group_indices["above"]:
+            above_inputs = keras.ops.take(inputs, self.group_indices["above"], axis=self.axis)
+            above = keras.activations.softplus(above_inputs)
+            above = anchor_input + keras.ops.cumsum(above, axis=self.axis)
+            parts.append(above)
 
         # Concatenate and reshape back
-        x = keras.ops.concatenate([below, anchor_input, above], self.axis)
-        return x
+        if len(parts) == 1:
+            return parts[0]
+        return keras.ops.concatenate(parts, self.axis)
 
     @sanitize_input_shape
     def compute_output_shape(self, input_shape):

--- a/bayesflow/links/ordered_quantiles.py
+++ b/bayesflow/links/ordered_quantiles.py
@@ -43,7 +43,7 @@ class OrderedQuantiles(Ordered):
             )
         else:
             # choose quantile level closest to median as anchor index
-            self.anchor_index = keras.ops.argmin(keras.ops.abs(keras.ops.convert_to_tensor(self.q) - 0.5))
+            self.anchor_index = int(keras.ops.argmin(keras.ops.abs(keras.ops.convert_to_tensor(self.q) - 0.5)))
 
             if len(self.q) != num_quantile_levels:
                 raise RuntimeError(

--- a/bayesflow/links/ordered_quantiles.py
+++ b/bayesflow/links/ordered_quantiles.py
@@ -51,10 +51,4 @@ class OrderedQuantiles(Ordered):
                     f"position {self.axis} of shape={input_shape}"
                 )
 
-        if self.anchor_index in [0, -1, num_quantile_levels - 1]:
-            raise RuntimeError(
-                f"The link function `OrderedQuantiles` expects at least 3 quantile levels, "
-                f"but only {num_quantile_levels} were given."
-            )
-
         super().build(input_shape)

--- a/tests/test_links/conftest.py
+++ b/tests/test_links/conftest.py
@@ -82,3 +82,9 @@ def quantiles(request):
 @pytest.fixture()
 def unordered(batch_size, num_quantiles, num_variables):
     return keras.random.normal((batch_size, num_quantiles, num_variables))
+
+
+@pytest.fixture(params=[1, 2])
+def unordered_short(batch_size, num_variables, request):
+    length = request.param
+    return keras.random.normal((batch_size, length, num_variables))

--- a/tests/test_links/test_links.py
+++ b/tests/test_links/test_links.py
@@ -39,6 +39,16 @@ def test_ordering(axis, unordered):
     check_ordering(output, axis)
 
 
+def test_ordering_short_axis(unordered_short):
+    from bayesflow.links import Ordered
+
+    axis = 1
+    # anchor_index=0 is valid for both lengths. For length 1, it is trivially ordered, only tests not crashing
+    activation = Ordered(axis=axis, anchor_index=0)
+    output = activation(unordered_short)
+    check_ordering(output, axis)
+
+
 def test_quantile_ordering(quantiles, unordered):
     from bayesflow.links import OrderedQuantiles
 


### PR DESCRIPTION
Removing a minor annoyance: The way `bayesflow.links.Ordered/OrderedQuantiles` was implemented the ordered axis could never be shorter than 3. Consequently, the smallest possible `QuantileScore` head still needed to predict three quantiles, e.g. `QuantileScore([0.1, 0.5, 0.9])`, where the central quantile is used as an anchor and below and above are transformed to be positive and substracted/added to the anchor.

Also ensure int type of inferred anchor index and check whether in bounds if passed explicitly.