### PR TITLE
Fix computation of marginal Bayes (N)RMSE

### DIFF
--- a/bayesflow/diagnostics/metrics/root_mean_squared_error.py
+++ b/bayesflow/diagnostics/metrics/root_mean_squared_error.py
@@ -90,7 +90,9 @@ def root_mean_squared_error(
         variable_names=variable_names,
     )
 
-    rmse = np.sqrt(np.mean((samples["estimates"] - samples["targets"][:, None, :]) ** 2, axis=0))
+    err = samples["estimates"] - samples["targets"][:, None, :]
+    rmse = np.sqrt(np.mean(err**2, axis=1))
+
     targets = samples["targets"]
 
     match normalize:
@@ -123,7 +125,7 @@ def root_mean_squared_error(
         case _:
             raise ValueError(f"Unknown normalization mode: {normalize}")
 
-    rmse /= normalizer[None, ...]
+    rmse = rmse / normalizer
     rmse = aggregation(rmse, axis=0)
 
     variable_names = samples["estimates"].variable_names

--- a/bayesflow/diagnostics/metrics/root_mean_squared_error.py
+++ b/bayesflow/diagnostics/metrics/root_mean_squared_error.py
@@ -2,6 +2,8 @@ from collections.abc import Sequence, Mapping, Callable
 
 import numpy as np
 
+from bayesflow.utils import logging
+
 from ...utils.dict_utils import dicts_to_arrays, compute_test_quantities
 
 
@@ -11,11 +13,13 @@ def root_mean_squared_error(
     variable_keys: Sequence[str] = None,
     variable_names: Sequence[str] = None,
     test_quantities: dict[str, Callable] = None,
-    normalize: str | None = "range",
+    normalize: str | None = "prior",
     aggregation: Callable = np.median,
 ) -> dict[str, any]:
     """
     Computes the (Normalized) Root Mean Squared Error (RMSE/NRMSE) for the given posterior and prior samples.
+    The values of the default normalization (`prior`) should be interpreted as 0 indicating the most informative
+    (posterior is a point mass at ground truth) and 1 indicating non-informative (posterior equals prior) results.
 
     Parameters
     ----------
@@ -45,7 +49,7 @@ def root_mean_squared_error(
         ``(batch_size,)``.
         The functions do not have to deal with an additional
         sample dimension, as appropriate reshaping is done internally.
-    normalize      : str or None, optional (default = "range")
+    normalize      : str or None, optional (default = "prior")
         Whether to normalize the RMSE using statistics of the prior samples.
         Possible options are ("mean", "range", "median", "iqr", "std", "prior", None)
     aggregation    : callable, optional (default = np.median)
@@ -68,6 +72,12 @@ def root_mean_squared_error(
         - "variable_names" : str
             The (inferred) variable names.
     """
+
+    if normalize is not None:
+        logging.warning(
+            "Using new default normalize='prior' for a more dynamic range. "
+            "To reproduce previous behavior, set normalize='range'."
+        )
 
     # Optionally, compute and prepend test quantities from draws
     if test_quantities is not None:
@@ -98,44 +108,39 @@ def root_mean_squared_error(
     match normalize:
         case None | False:
             normalizer = np.array(1.0)
-            metric_name = "RMSE"
 
         case "mean":
             normalizer = np.mean(targets, axis=0)
-            metric_name = "NRMSE"
 
         case "median":
             normalizer = np.median(targets, axis=0)
-            metric_name = "NRMSE"
 
         case "range":
             normalizer = targets.max(axis=0) - targets.min(axis=0)
-            metric_name = "NRMSE"
 
         case "std":
             normalizer = np.std(targets, axis=0, ddof=0)
-            metric_name = "NRMSE"
 
         case "iqr":
             q75 = np.percentile(targets, 75, axis=0)
             q25 = np.percentile(targets, 25, axis=0)
             normalizer = q75 - q25
-            metric_name = "NRMSE"
 
         case "prior":
-            N, S, D = samples["estimates"].shape
+            N, S, _ = samples["estimates"].shape
 
             # bootstrap prior-only predictions from empirical prior samples in targets
             idx = np.random.randint(0, N, size=(N, S))
-            prior_estimates = targets[idx]
+            prior_bootstrap = targets[idx]
 
-            prior_err = prior_estimates - targets[:, None, :]
+            prior_err = prior_bootstrap - targets[:, None, :]
             prior_rmse = np.sqrt(np.mean(prior_err**2, axis=1))
             normalizer = aggregation(prior_rmse, axis=0)
-            metric_name = "NRMSE"
 
         case _:
             raise ValueError(f"Unknown normalization mode: {normalize}")
+
+    metric_name = "NRMSE" if normalize else "RMSE"
 
     rmse = rmse / normalizer
     rmse = aggregation(rmse, axis=0)

--- a/bayesflow/diagnostics/metrics/root_mean_squared_error.py
+++ b/bayesflow/diagnostics/metrics/root_mean_squared_error.py
@@ -73,7 +73,7 @@ def root_mean_squared_error(
             The (inferred) variable names.
     """
 
-    if normalize is not None:
+    if normalize:
         logging.warning(
             "Using new default normalize='prior' for a more dynamic range. "
             "To reproduce previous behavior, set normalize='range'."

--- a/bayesflow/diagnostics/metrics/root_mean_squared_error.py
+++ b/bayesflow/diagnostics/metrics/root_mean_squared_error.py
@@ -47,7 +47,7 @@ def root_mean_squared_error(
         sample dimension, as appropriate reshaping is done internally.
     normalize      : str or None, optional (default = "range")
         Whether to normalize the RMSE using statistics of the prior samples.
-        Possible options are ("mean", "range", "median", "iqr", "std", None)
+        Possible options are ("mean", "range", "median", "iqr", "std", "prior", None)
     aggregation    : callable, optional (default = np.median)
         Function to aggregate the RMSE across draws. Typically `np.mean` or `np.median`.
 
@@ -120,6 +120,18 @@ def root_mean_squared_error(
             q75 = np.percentile(targets, 75, axis=0)
             q25 = np.percentile(targets, 25, axis=0)
             normalizer = q75 - q25
+            metric_name = "NRMSE"
+
+        case "prior":
+            N, S, D = samples["estimates"].shape
+
+            # bootstrap prior-only predictions from empirical prior samples in targets
+            idx = np.random.randint(0, N, size=(N, S))
+            prior_estimates = targets[idx]
+
+            prior_err = prior_estimates - targets[:, None, :]
+            prior_rmse = np.sqrt(np.mean(prior_err**2, axis=1))
+            normalizer = aggregation(prior_rmse, axis=0)
             metric_name = "NRMSE"
 
         case _:


### PR DESCRIPTION
This PR fixes the computation of marginal Bayes RMSE/NRMSE.

The previous implementation reduced over the num_ground_truths axis first, then aggregated over posterior samples. That computes an average over per-sample RMSEs across the dataset, which does not match the intended marginal Bayes metric.

The corrected implementation:

- computes squared error for each `(ground_truth, sample, dimension)`
- takes the mean over `num_samples`
- applies `sqrt`
- optionally normalizes per dimension
- aggregates over `num_ground_truths`