### PR TITLE
Fix wheel packaging: exclude tests/docs/examples and add CI content check

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,8 @@ jobs:
         --user
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
+    - name: Check wheel contents
+      run: pipx run check-wheel-contents dist/*.whl
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,8 +155,15 @@ docstring-code-format = true
 # enabled.
 docstring-code-line-length = "dynamic"
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.packages.find]
+include = ["bayesflow*"]
+namespaces = false
+
+[tool.check-wheel-contents]
+ignore = ["W002"]
 
 [tool.uv.sources]
 bayesflow = { workspace = true }


### PR DESCRIPTION
## Problem

The published wheel contained files that are generally not intended for end users:

- `tests/` (166 files) — pytest fixtures, test modules, conftest files
- `docsrc/` — Sphinx build scripts (`conf.py`, `pre-build.py`, etc.)
- `examples/` — Jupyter notebooks and supporting assets

This happened silently due to three setuptools behaviours interacting:

1. **`include_package_data = True` is the default** in pyproject.toml mode. With a flat layout, setuptools collects all git-tracked files from the project root, not just files inside the `bayesflow` package directory.
2. **`tests/` was discovered as a Python package** — it has a top-level `__init__.py`, so `find_packages()` with no include filter picks it up.
3. **`docsrc/` and `examples/` were discovered as namespace packages** — Python 3 implicit namespace packages (no `__init__.py` required), included by default unless `namespaces = false` is set.

Running `check-wheel-contents` against the previous release wheel surfaces all of this:

```
W004: Module is not located at importable path: docsrc/generate-redirects.py, docsrc/pre-build.py
W005: Wheel contains common toplevel name in library: tests/, examples/
W009: Wheel contains multiple toplevel library entries: bayesflow/, docsrc/, examples/, tests/
```

### On `examples/`

Shipping examples in a wheel is a legitimate design choice for some packages. For BayesFlow the examples directory contains Jupyter notebooks and image assets — content that typically requires a full repo checkout and Jupyter environment to use, and is better accessed from the documentation site or by cloning the repo. If there is ever a desire to ship runnable examples as part of the installed package, the recommended approach is to move them under `bayesflow/examples/` (inside the package namespace) rather than as a bare top-level `examples/` entry, which can conflict with other installed packages named `examples` (what W005 flags).

## Fix

**`pyproject.toml`:**
- `include-package-data = false` — disables git-based file collection (the root cause)
- `packages.find.include = ["bayesflow*"]` — restricts package discovery to the `bayesflow` package and subpackages only
- `packages.find.namespaces = false` — disables namespace package discovery, preventing `docsrc/` and `examples/` from being picked up

W002 ("duplicate files") is suppressed via `[tool.check-wheel-contents] ignore = ["W002"]` — it is a false positive caused by two `__init__.py` files that happen to have identical content (`from .mamba import Mamba`) but serve different roles in the package hierarchy.

**`.github/workflows/publish.yaml`:**
Adds a `check-wheel-contents` step between build and artifact upload so any future regression in wheel contents blocks the release before it reaches PyPI.

## Verification

After the fix, `check-wheel-contents dist/*.whl` reports `OK` and the wheel contains only `bayesflow/` and `bayesflow-2.0.11.dist-info/`.