### PR TITLE
Pin GitHub Actions to commit SHAs for supply-chain security

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -28,7 +28,7 @@ jobs:
     - name: Check wheel contents
       run: pipx run check-wheel-contents dist/*.whl
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: python-package-distributions
         path: dist/
@@ -47,9 +47,9 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.11
           cache: "pip"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -99,7 +99,7 @@ jobs:
           coverage xml
 
       - name: Upload Coverage Reports to CodeCov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           # do not use the files attribute here, otherwise the reports are not merged correctly
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Replace mutable version tags with pinned commit SHAs across all GitHub Actions workflows, retaining the version as an inline comment for readability.

**Versions were updated to match what Dependabot already merged into `main`** before adding SHA pins:

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | `v6` | `de0fac2e` |
| `actions/setup-python` | `v6` | `a309ff8b` |
| `actions/upload-artifact` | `v7` | `043fb46d` |
| `actions/download-artifact` | `v8` | `3e5f45b2` |
| `codecov/codecov-action` | `v6` | `57e3a136` |
| `pypa/gh-action-pypi-publish` | `release/v1` | `cef22109` |

## Why

Pinning to SHAs prevents a compromised or force-pushed tag from silently injecting malicious code into CI. This is a supply-chain hardening measure flagged by [zizmor](https://github.com/woodruffw/zizmor), which is already part of this repo's CI.

## Maintenance

Dependabot is configured (`dependabot.yml`) to open PRs for version updates. When those land, the SHA pins here should be updated to match the new tags, keeping the inline `# vN` comments in sync.