### PR TITLE
Fix CouplingFlows for 1D inputs under Keras 3.13

### DIFF
--- a/bayesflow/networks/inference/coupling/layers/dual_coupling.py
+++ b/bayesflow/networks/inference/coupling/layers/dual_coupling.py
@@ -76,12 +76,13 @@ class DualCoupling(InvertibleLayer):
     def _forward(self, x: Tensor, conditions: Tensor = None, training: bool = False, **kwargs) -> tuple[Tensor, Tensor]:
         """Transform (x1, x2) -> (g(x1; f(x2; x1)), f(x2; x1))"""
         x1, x2 = x[..., : self.pivot], x[..., self.pivot :]
-        (z1, z2), log_det = self.coupling1(x1, x2, conditions=conditions, training=training, **kwargs)
+        (z1, z2), log_det1 = self.coupling1(x1, x2, conditions=conditions, training=training, **kwargs)
 
+        log_det2 = 0
         if self.pivot:
             (z2, z1), log_det2 = self.coupling2(z2, z1, conditions=conditions, training=training, **kwargs)
-            log_det = log_det + log_det2
 
+        log_det = log_det1 + log_det2
         z = keras.ops.concatenate([z1, z2], axis=-1)
 
         return z, log_det

--- a/bayesflow/networks/inference/coupling/layers/dual_coupling.py
+++ b/bayesflow/networks/inference/coupling/layers/dual_coupling.py
@@ -62,7 +62,9 @@ class DualCoupling(InvertibleLayer):
         x2_shape = xz_shape[:-1] + (xz_shape[-1] - self.pivot,)
 
         self.coupling1.build(x1_shape, x2_shape, conditions_shape)
-        self.coupling2.build(x2_shape, x1_shape, conditions_shape)
+
+        if self.pivot:
+            self.coupling2.build(x2_shape, x1_shape, conditions_shape)
 
     def call(
         self, xz: Tensor, conditions: Tensor = None, inverse: bool = False, training: bool = False, **kwargs
@@ -74,18 +76,26 @@ class DualCoupling(InvertibleLayer):
     def _forward(self, x: Tensor, conditions: Tensor = None, training: bool = False, **kwargs) -> tuple[Tensor, Tensor]:
         """Transform (x1, x2) -> (g(x1; f(x2; x1)), f(x2; x1))"""
         x1, x2 = x[..., : self.pivot], x[..., self.pivot :]
-        (z1, z2), log_det1 = self.coupling1(x1, x2, conditions=conditions, training=training, **kwargs)
-        (z2, z1), log_det2 = self.coupling2(z2, z1, conditions=conditions, training=training, **kwargs)
+        (z1, z2), log_det = self.coupling1(x1, x2, conditions=conditions, training=training, **kwargs)
+
+        if self.pivot:
+            (z2, z1), log_det2 = self.coupling2(z2, z1, conditions=conditions, training=training, **kwargs)
+            log_det = log_det + log_det2
 
         z = keras.ops.concatenate([z1, z2], axis=-1)
-        log_det = log_det1 + log_det2
 
         return z, log_det
 
     def _inverse(self, z: Tensor, conditions: Tensor = None, training: bool = False, **kwargs) -> tuple[Tensor, Tensor]:
         """Transform (g(x1; f(x2; x1)), f(x2; x1)) -> (x1, x2)"""
         z1, z2 = z[..., : self.pivot], z[..., self.pivot :]
-        (z2, z1), log_det2 = self.coupling2(z2, z1, conditions=conditions, inverse=True, training=training, **kwargs)
+
+        log_det2 = 0
+        if self.pivot:
+            (z2, z1), log_det2 = self.coupling2(
+                z2, z1, conditions=conditions, inverse=True, training=training, **kwargs
+            )
+
         (x1, x2), log_det1 = self.coupling1(z1, z2, conditions=conditions, inverse=True, training=training, **kwargs)
 
         x = keras.ops.concatenate([x1, x2], axis=-1)


### PR DESCRIPTION
The following breaks on `keras==3.13`, but not on `keras==3.12`

```
import bayesflow as bf

x = bf.networks.CouplingFlow()

y = keras.ops.ones((32, 1))
conditions = keras.ops.ones((32, 8))

x(y, conditions=conditions)
```

```
ValueError                                Traceback (most recent call last)
Cell In[7], line 1
----> 1 x(y, conditions=conditions)

File /data/work/projects/bayesflow/.venv/lib/python3.12/site-packages/keras/src/utils/traceback_utils.py:122, in filter_traceback.<locals>.error_handler(*args, **kwargs)
    119     filtered_tb = _process_traceback_frames(e.__traceback__)
    120     # To get the full stack trace, call:
    121     # `keras.config.disable_traceback_filtering()`
--> 122     raise e.with_traceback(filtered_tb) from None
    123 finally:
    124     del filtered_tb

File /data/work/projects/bayesflow/bayesflow/networks/inference/coupling/coupling_flow.py:129, in CouplingFlow.build(self, xz_shape, conditions_shape)
    126     return
    128 for layer in self.invertible_layers:
--> 129     layer.build(xz_shape=xz_shape, conditions_shape=conditions_shape)
    131 self.base_distribution.build(xz_shape)

File /data/work/projects/bayesflow/bayesflow/networks/inference/coupling/layers/dual_coupling.py:65, in DualCoupling.build(self, xz_shape, conditions_shape)
     62 x2_shape = xz_shape[:-1] + (xz_shape[-1] - self.pivot,)
     64 self.coupling1.build(x1_shape, x2_shape, conditions_shape)
---> 65 self.coupling2.build(x2_shape, x1_shape, conditions_shape)

File /data/work/projects/bayesflow/bayesflow/networks/inference/coupling/layers/single_coupling.py:73, in SingleCoupling.build(self, x1_shape, x2_shape, conditions_shape)
     72 def build(self, x1_shape: Shape, x2_shape: Shape, conditions_shape: Shape = None):
---> 73     self.output_projector = keras.layers.Dense(
     74         units=self.transform.params_per_dim * x2_shape[-1],
     75         kernel_initializer="zeros",
     76         bias_initializer="zeros",
     77         name="output_projector",
     78     )
     80     if conditions_shape is not None:
     81         subnet_input_shape = tuple(x1_shape[:-1]) + (x1_shape[-1] + conditions_shape[-1],)

ValueError: Received an invalid value for `units`, expected a positive integer. Received: units=0
```

If I understand it correctly, the issue stems from the fact that `coupling2` in `DualCoupling` receives a length 0 input for 1D inference networks, and `Dense(units=0)` works under `keras==3.12` but not `keras==3.13`.

I'm not sure what the best fix for this is, this PR builds and calls `coupling2` only if the input dimension is > 1, which seems to work fine, but I'm not familiar to know if this has any hidden implications.