### PR TITLE
Add option for changing kernel_size in convolutional summary

### DIFF
--- a/bayesflow/networks/summary/convolutional/convolutional_network.py
+++ b/bayesflow/networks/summary/convolutional/convolutional_network.py
@@ -31,6 +31,9 @@ class ConvolutionalNetwork(SummaryNetwork):
         Dimensionality of the output summary vector. Default is 16.
     widths : Sequence[int], optional
         Number of convolutional filters per stage. Default is ``(32, 64, 128)``.
+    kernel_sizes : int or Sequence[int], optional
+        Kernel size of the convolution per stage. Default is ``3``. ``int`` is
+        broadcast to evert width.
     blocks_per_stage : int or Sequence[int], optional
         Residual blocks per stage. A single int is broadcast to every stage.
         Default is 2.
@@ -71,6 +74,7 @@ class ConvolutionalNetwork(SummaryNetwork):
         self,
         summary_dim: int = 16,
         widths: Sequence[int] = (32, 64, 128),
+        kernel_sizes: int | Sequence[int] = 3,
         blocks_per_stage: int | Sequence[int] = 2,
         downsample_stage: Sequence[bool] | bool = True,
         norm: Literal["layer", "group", "batch"] | None = "layer",
@@ -94,6 +98,7 @@ class ConvolutionalNetwork(SummaryNetwork):
 
         self.summary_dim = summary_dim
         self.widths = widths
+        self.kernel_sizes = [kernel_sizes] * len(widths) if isinstance(kernel_sizes, int) else list(kernel_sizes)
 
         self.blocks_per_stage = (
             [blocks_per_stage] * len(widths) if isinstance(blocks_per_stage, int) else list(blocks_per_stage)
@@ -114,9 +119,19 @@ class ConvolutionalNetwork(SummaryNetwork):
 
     def _build_stages(self):
         layers = []
-        for width, num_blocks, downsample in zip(self.widths, self.blocks_per_stage, self.downsample_stage):
+        for width, kernel_size, num_blocks, downsample in zip(
+            self.widths, self.kernel_sizes, self.blocks_per_stage, self.downsample_stage
+        ):
             for _ in range(num_blocks):
-                block = DoubleConv(width, self.norm, self.groups, self.dropout, self.activation, residual=self.residual)
+                block = DoubleConv(
+                    width=width,
+                    kernel_size=kernel_size,
+                    norm=self.norm,
+                    groups=self.groups,
+                    dropout=self.dropout,
+                    activation=self.activation,
+                    residual=self.residual,
+                )
                 layers.append(block)
 
             if downsample:

--- a/bayesflow/networks/summary/convolutional/double_conv.py
+++ b/bayesflow/networks/summary/convolutional/double_conv.py
@@ -21,6 +21,7 @@ class DoubleConv(keras.Layer):
     def __init__(
         self,
         width: int,
+        kernel_size: int = 3,
         norm: Literal["layer", "group", "batch"] | None = "group",
         groups: int | None = 8,
         dropout: float = None,
@@ -35,10 +36,10 @@ class DoubleConv(keras.Layer):
             # https://github.com/keras-team/keras/issues/1802#issuecomment-187966878
             gamma_initializer = "zeros" if residual else "ones"
             conv_layers = [
-                keras.layers.Conv2D(width, 3, padding="same"),
+                keras.layers.Conv2D(width, kernel_size=kernel_size, padding="same"),
                 keras.layers.Activation(activation),
                 SimpleNorm(method=norm),
-                keras.layers.Conv2D(width, 3, padding="same"),
+                keras.layers.Conv2D(width, kernel_size=kernel_size, padding="same"),
                 keras.layers.Activation(activation),
                 SimpleNorm(method=norm, gamma_initializer=gamma_initializer),
                 keras.layers.Dropout(0.0 if dropout is None else dropout),
@@ -49,16 +50,19 @@ class DoubleConv(keras.Layer):
             conv_layers = [
                 SimpleNorm(method=norm, groups=groups, center=True, scale=True),
                 keras.layers.Activation(activation),
-                keras.layers.Conv2D(width, 3, padding="same"),
+                keras.layers.Conv2D(width, kernel_size=kernel_size, padding="same"),
                 SimpleNorm(method=norm, groups=groups, center=True, scale=True),
                 keras.layers.Activation(activation),
                 keras.layers.Dropout(0.0 if dropout is None else dropout),
-                keras.layers.Conv2D(width, 3, padding="same", kernel_initializer=kernel_initializer),
+                keras.layers.Conv2D(
+                    width, kernel_size=kernel_size, padding="same", kernel_initializer=kernel_initializer
+                ),
             ]
 
         self.conv_layers = conv_layers
         self.width = width
         self.norm = norm
+        self.kernel_size = kernel_size
         self.groups = groups
         self.dropout = dropout
         self.activation = activation
@@ -75,6 +79,7 @@ class DoubleConv(keras.Layer):
         config = {
             "width": self.width,
             "norm": self.norm,
+            "kernel_size": self.kernel_size,
             "groups": self.groups,
             "dropout": self.dropout,
             "activation": self.activation,

--- a/docsrc/source/user_guide/datasets.ipynb
+++ b/docsrc/source/user_guide/datasets.ipynb
@@ -352,6 +352,7 @@
     "        summary_network=bf.networks.ConvolutionalNetwork(\n",
     "            summary_dim=8,\n",
     "            widths=(8, 16),\n",
+    "            kernel_sizes=(3, 3),\n",
     "            blocks_per_stage=1,\n",
     "        ),\n",
     "        inference_variables=[\"parameters\"],\n",

--- a/examples/Spatial_Data_and_Parameters.ipynb
+++ b/examples/Spatial_Data_and_Parameters.ipynb
@@ -360,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "346fabf8df503b45",
    "metadata": {
     "ExecuteTime": {
@@ -372,7 +372,7 @@
    "source": [
     "summary_network = bf.networks.ConvolutionalNetwork(\n",
     "    summary_dim=6,\n",
-    "    widths=[8, 16, 32, 64],\n",
+    "    widths=(8, 16, 32, 64),\n",
     "    blocks_per_stage=1,\n",
     "    down_mode=\"max_pool\",\n",
     "    pool_head=\"flatten\",\n",

--- a/tests/test_networks/test_summary_networks/test_convolutional_network.py
+++ b/tests/test_networks/test_summary_networks/test_convolutional_network.py
@@ -117,6 +117,7 @@ def test_multi_block_stages():
     net = ConvolutionalNetwork(
         summary_dim=SUMMARY_DIM,
         widths=(4, 8),
+        kernel_sizes=(2, 2),
         blocks_per_stage=2,
         downsample_stage=(True, False),
     )


### PR DESCRIPTION
Adds an optional `int` or a `Sequence` argument `kernel_sizes` to `ConvolutionalNetwork` to allow adjusting the filter sizes in each stage.

The following work

```
summary_network = bf.networks.ConvolutionalNetwork(
    widths=(8, 16),
    kernel_sizes=3, # default, will be propagated to (3, 3)
    blocks_per_stage=1,
)
```

```
summary_network = bf.networks.ConvolutionalNetwork(
    widths=(8, 16),
    kernel_sizes=(3, 3),
    blocks_per_stage=1,
)
```