### PR TITLE
Add seed sequencing for parallel simulation and test

### DIFF
--- a/bayesflow/simulators/sequential_simulator.py
+++ b/bayesflow/simulators/sequential_simulator.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 import numpy as np
 
 from bayesflow.types import Shape
+from bayesflow.utils import reseed_random_state
 from bayesflow.utils.decorators import allow_batch_size
 
 from .simulator import Simulator
@@ -71,7 +72,9 @@ class SequentialSimulator(Simulator):
 
         return data
 
-    def _single_sample(self, batch_shape_ext, **kwargs) -> dict[str, np.ndarray]:
+    def _single_sample(
+        self, batch_shape_ext, seed_sequence: np.random.SeedSequence = None, **kwargs
+    ) -> dict[str, np.ndarray]:
         """
         For single sample used by parallel sampling.
 
@@ -85,10 +88,13 @@ class SequentialSimulator(Simulator):
         dict
             Single sample result.
         """
+        if seed_sequence is not None:
+            reseed_random_state((self, kwargs), seed_sequence)
+
         return self.sample(batch_shape=(1, *tuple(batch_shape_ext)), **kwargs)
 
     def sample_parallel(
-        self, batch_shape: Shape, n_jobs: int = -1, verbose: int = 0, **kwargs
+        self, batch_shape: Shape, n_jobs: int = -1, verbose: int = 0, seed: int = None, **kwargs
     ) -> dict[str, np.ndarray]:
         """
         Sample in parallel from the sequential simulator.
@@ -102,6 +108,9 @@ class SequentialSimulator(Simulator):
             Number of parallel jobs. -1 uses all available cores. Default is -1.
         verbose : int, optional
             Verbosity level for joblib. Default is 0 (no output).
+        seed : int, optional
+            Seed used to derive independent random streams for each parallel task. If None, entropy from
+            the operating system is used.
         **kwargs
             Additional keyword arguments passed to each simulator. These may include previously
             sampled outputs used as inputs for subsequent simulators.
@@ -128,8 +137,11 @@ class SequentialSimulator(Simulator):
         if len(bs) == 0:
             raise ValueError("batch_shape must be a positive integer or a nonempty tuple")
 
+        seed_sequences = np.random.SeedSequence(seed).spawn(bs[0])
+
         results = Parallel(n_jobs=n_jobs, verbose=verbose)(
-            delayed(self._single_sample)(batch_shape_ext=bs[1:], **kwargs) for _ in range(bs[0])
+            delayed(self._single_sample)(batch_shape_ext=bs[1:], seed_sequence=seed_sequences[i], **kwargs)
+            for i in range(bs[0])
         )
         return self._combine_results(results)
 

--- a/bayesflow/utils/__init__.py
+++ b/bayesflow/utils/__init__.py
@@ -8,6 +8,7 @@ from . import (
     keras_utils,
     logging,
     numpy_utils,
+    rng,
     serialization,
     tree,
 )
@@ -79,6 +80,8 @@ from .plot_utils import (
 )
 from .serialization import serialize_value_or_type, deserialize_value_or_type
 
+from .rng import next_seed_sequence, next_uint32, reseed_generator, reseed_random_state
+
 from .tensor_utils import (
     concatenate_valid,
     concatenate_valid_shapes,
@@ -117,4 +120,4 @@ from ._docs import _add_imports_to_all
 
 from .logging import format_duration
 
-_add_imports_to_all(include_modules=["keras_utils", "logging", "numpy_utils", "serialization", "tree"])
+_add_imports_to_all(include_modules=["keras_utils", "logging", "numpy_utils", "rng", "serialization", "tree"])

--- a/bayesflow/utils/rng.py
+++ b/bayesflow/utils/rng.py
@@ -1,0 +1,109 @@
+from collections.abc import Mapping
+import functools
+import inspect
+import random as random_module
+
+import numpy as np
+
+
+def next_seed_sequence(seed_sequence: np.random.SeedSequence) -> np.random.SeedSequence:
+    return seed_sequence.spawn(1)[0]
+
+
+def next_uint32(seed_sequence: np.random.SeedSequence) -> int:
+    return int(next_seed_sequence(seed_sequence).generate_state(1, dtype=np.uint32)[0])
+
+
+def reseed_generator(rng: np.random.Generator, seed_sequence: np.random.SeedSequence) -> None:
+    bit_generator_type = type(rng.bit_generator)
+    rng.bit_generator.state = bit_generator_type(next_seed_sequence(seed_sequence)).state
+
+
+def reseed_random_state(root: object, seed_sequence: np.random.SeedSequence) -> None:
+    """Reseed RNGs reachable from a worker-local object copy."""
+
+    random_module.seed(next_uint32(seed_sequence))
+    np.random.seed(next_uint32(seed_sequence))
+
+    seen = set()
+
+    def visit(obj):
+        obj_id = id(obj)
+        if obj_id in seen:
+            return
+
+        seen.add(obj_id)
+
+        if isinstance(obj, np.random.Generator):
+            reseed_generator(obj, seed_sequence)
+            return
+
+        if isinstance(obj, np.random.RandomState):
+            obj.seed(next_uint32(seed_sequence))
+            return
+
+        if isinstance(obj, random_module.Random):
+            obj.seed(next_uint32(seed_sequence))
+            return
+
+        if obj is None or isinstance(obj, (str, bytes, int, float, complex, bool, np.ndarray)):
+            return
+
+        if inspect.ismodule(obj) or inspect.isclass(obj):
+            return
+
+        if inspect.ismethod(obj):
+            visit(obj.__self__)
+            visit(obj.__func__)
+            return
+
+        if inspect.isfunction(obj):
+            visit(obj.__defaults__)
+            visit(obj.__kwdefaults__)
+            visit(getattr(obj, "__dict__", None))
+
+            if obj.__closure__ is not None:
+                for cell in obj.__closure__:
+                    try:
+                        visit(cell.cell_contents)
+                    except ValueError:
+                        pass
+
+            for name in obj.__code__.co_names:
+                if name in obj.__globals__:
+                    visit(obj.__globals__[name])
+
+            return
+
+        if isinstance(obj, functools.partial):
+            visit(obj.func)
+            visit(obj.args)
+            visit(obj.keywords)
+            return
+
+        if isinstance(obj, Mapping):
+            for value in obj.values():
+                visit(value)
+            return
+
+        if isinstance(obj, (list, tuple, set, frozenset)):
+            for value in obj:
+                visit(value)
+            return
+
+        try:
+            visit(vars(obj))
+        except TypeError:
+            pass
+
+        slots = getattr(type(obj), "__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+
+        for slot in slots:
+            try:
+                visit(getattr(obj, slot))
+            except AttributeError:
+                pass
+
+    visit(root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
 test = [
   "ipykernel>=7.1.0",
   "ipython>=8.38.0",
+  "joblib>=1.5.2",
   "nbconvert>=7.16.6",
   "pytest>=9.0.2",
   "pytest-cov>=7.0.0",

--- a/tests/test_simulators/test_simulators.py
+++ b/tests/test_simulators/test_simulators.py
@@ -3,6 +3,39 @@ import keras
 import numpy as np
 
 
+def assert_unique_rows(array):
+    rows = np.reshape(array, (array.shape[0], -1))
+    assert np.unique(rows, axis=0).shape[0] == rows.shape[0]
+
+
+def test_sample_parallel_reseeds_worker_rngs():
+    pytest.importorskip("joblib")
+
+    from bayesflow.simulators import LambdaSimulator, SequentialSimulator
+
+    closure_rng = np.random.default_rng(123)
+
+    def closure_prior():
+        return {"closure": closure_rng.integers(0, 2**31 - 1, size=4)}
+
+    class AttributePrior:
+        def __init__(self):
+            self.rng = np.random.default_rng(456)
+
+        def sample(self, batch_shape, **kwargs):
+            return {"attribute": self.rng.integers(0, 2**31 - 1, size=tuple(batch_shape) + (4,))}
+
+    def make_simulator():
+        return SequentialSimulator([LambdaSimulator(closure_prior), AttributePrior()])
+
+    first = make_simulator().sample_parallel((12,), n_jobs=2, seed=789)
+    second = make_simulator().sample_parallel((12,), n_jobs=2, seed=789)
+
+    for key, value in first.items():
+        np.testing.assert_array_equal(value, second[key])
+        assert_unique_rows(value)
+
+
 def test_two_moons(two_moons_simulator, batch_size):
     samples = two_moons_simulator.sample((batch_size,))
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pytest
     pytest-cov
     pytest-rerunfailures
+    joblib
     scikit-learn
     matplotlib
     seaborn


### PR DESCRIPTION
## Summary

This PR fixes a nasty `sample_parallel` RNG issue (https://github.com/bayesflow-org/bayesflow/issues/723) that could show up on Windows.

Previously, each joblib task received a pickled copy of the simulator. If the simulator carried random state, for example through `self.rng`, a closed-over `np.random.default_rng()`, or global `np.random` state, multiple workers start from the exact same RNG state.

The fix makes `sample_parallel` create one independent `SeedSequence` per simulated batch element. Each worker reseeds its local copy of any reachable RNG state before running the user simulator:

- Added RNG utilities in `bayesflow/utils/rng.py`.
- `SequentialSimulator.sample_parallel(..., seed=...)` now derives independent worker seeds.
- Each parallel task reseeds:
  - global `np.random`
  - Python `random`
  - reachable `np.random.Generator`
  - reachable `np.random.RandomState`
  - RNGs stored on simulator attributes
  - RNGs captured in closures / globals
- Also added a test that fails under the old behavior by checking that parallel samples from cloned RNGs are not duplicated.
- Added `joblib` to test dependencies so this path is actually covered.

## Schematic

```text
sample_parallel(batch_shape=(N,), seed=789)
        |
        v
root SeedSequence(789)
        |
        +-- child seed 0 ---> joblib task 0
        |                      reseed worker-local simulator copy
        |                      run self.sample(batch_shape=(1,))
        |
        +-- child seed 1 ---> joblib task 1
        |                      reseed worker-local simulator copy
        |                      run self.sample(batch_shape=(1,))
        |
        +-- child seed 2 ---> joblib task 2
        |                      reseed worker-local simulator copy
        |                      run self.sample(batch_shape=(1,))
        |
       ...
        |
        v
combine single-sample dictionaries back into one batch