### PR TITLE
add output projector option to diffusion models

### DIFF
--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -206,10 +206,7 @@ class ConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if self._project_output is None:
-            # a subnet whose output already has the target width projects into target space itself
-            self._project_output = out_shape[-1] != xz_shape[-1]
-        if self._project_output:
+        if out_shape[-1] != xz_shape[-1]:
             self.output_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -115,7 +115,6 @@ class ConsistencyModel(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.output_projector = None
-        self._project_output = kwargs.pop("project_output", None)
         self.sigma2 = ops.convert_to_tensor(sigma2)
         self.sigma = ops.sqrt(sigma2)
         self.eps = eps
@@ -166,16 +165,10 @@ class ConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "project_output": self._project_output,
             # we do not need to store subnet_kwargs
         }
 
         return base_config | serialize(config)
-
-    @classmethod
-    def from_config(cls, config, custom_objects=None):
-        # Older configs may have no "project_output" key and always used a Dense projector.
-        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     def _schedule_discretization(self, step) -> float:
         """Schedule function for adjusting the discretization level `N(k)` during

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -66,6 +66,10 @@ class ConsistencyModel(InferenceNetwork):
     subnet_kwargs : dict[str, any], optional
         Keyword arguments passed to the subnet constructor or used to update the
         default MLP settings.
+    output_projector : keras.layers.Layer, optional
+        The output projector is applied to the subnet output. Default is a dense layer to map
+        the subnets output to the inference variable dimension.
+        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``.
 
@@ -100,6 +104,7 @@ class ConsistencyModel(InferenceNetwork):
         noise_dist_mean: float = -1.1,
         noise_dist_std: float = 2.0,
         subnet_kwargs: dict[str, any] = None,
+        output_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution="normal", **kwargs)
@@ -114,7 +119,12 @@ class ConsistencyModel(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        self.output_projector = None
+        if output_projector is not None:
+            self.output_projector = output_projector
+        elif subnet == "diffusion_transformer":
+            self.output_projector = keras.layers.Identity()
+        else:
+            self.output_projector = None  # defaults to a dense layer
 
         self.sigma2 = ops.convert_to_tensor(sigma2)
         self.sigma = ops.sqrt(sigma2)
@@ -166,6 +176,7 @@ class ConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "output_projector": self.output_projector,
             # we do not need to store subnet_kwargs
         }
 
@@ -203,11 +214,12 @@ class ConsistencyModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        self.output_projector = keras.layers.Dense(
-            units=xz_shape[-1],
-            bias_initializer="zeros",
-            name="output_projector",
-        )
+        if self.output_projector is None:
+            self.output_projector = keras.layers.Dense(
+                units=xz_shape[-1],
+                bias_initializer="zeros",
+                name="output_projector",
+            )
 
         # construct input shape for subnet and subnet projector
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -115,6 +115,7 @@ class ConsistencyModel(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.output_projector = None
+        self._project_output = kwargs.pop("project_output", None)
         self.sigma2 = ops.convert_to_tensor(sigma2)
         self.sigma = ops.sqrt(sigma2)
         self.eps = eps
@@ -165,10 +166,16 @@ class ConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "project_output": self._project_output,
             # we do not need to store subnet_kwargs
         }
 
         return base_config | serialize(config)
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        # Older configs may have no "project_output" key and always used a Dense projector.
+        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     def _schedule_discretization(self, step) -> float:
         """Schedule function for adjusting the discretization level `N(k)` during
@@ -206,15 +213,17 @@ class ConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if out_shape[-1] == xz_shape[-1]:
-            # subnet already outputs in target space
-            self.output_projector = keras.layers.Identity()
-        else:
+        if self._project_output is None:
+            # a subnet whose output already has the target width projects into target space itself
+            self._project_output = out_shape[-1] != xz_shape[-1]
+        if self._project_output:
             self.output_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",
                 name="output_projector",
             )
+        else:
+            self.output_projector = keras.layers.Identity()
         self.output_projector.build(out_shape)
 
         # Choose coefficient according to [2] Section 3.3

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -225,7 +225,8 @@ class ConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        self.output_projector.build(out_shape)
+        if not self.output_projector.built:
+            self.output_projector.build(out_shape)
 
         # Choose coefficient according to [2] Section 3.3
         self._c_huber = 0.00054 * ops.sqrt(xz_shape[-1])

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -66,10 +66,6 @@ class ConsistencyModel(InferenceNetwork):
     subnet_kwargs : dict[str, any], optional
         Keyword arguments passed to the subnet constructor or used to update the
         default MLP settings.
-    output_projector : keras.layers.Layer, optional
-        The output projector is applied to the subnet output. Default is a dense layer to map
-        the subnets output to the inference variable dimension.
-        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``.
 
@@ -104,7 +100,6 @@ class ConsistencyModel(InferenceNetwork):
         noise_dist_mean: float = -1.1,
         noise_dist_std: float = 2.0,
         subnet_kwargs: dict[str, any] = None,
-        output_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution="normal", **kwargs)
@@ -119,13 +114,7 @@ class ConsistencyModel(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        if output_projector is not None:
-            self.output_projector = output_projector
-        elif subnet == "diffusion_transformer":
-            self.output_projector = keras.layers.Identity()
-        else:
-            self.output_projector = None  # defaults to a dense layer
-
+        self.output_projector = None
         self.sigma2 = ops.convert_to_tensor(sigma2)
         self.sigma = ops.sqrt(sigma2)
         self.eps = eps
@@ -176,7 +165,6 @@ class ConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "output_projector": self.output_projector,
             # we do not need to store subnet_kwargs
         }
 
@@ -214,7 +202,10 @@ class ConsistencyModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if self.output_projector is None:
+        if getattr(self.subnet, "projects_output", False):
+            # subnet already outputs in target space
+            self.output_projector = keras.layers.Identity()
+        else:
             self.output_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",
@@ -225,8 +216,7 @@ class ConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if not self.output_projector.built:
-            self.output_projector.build(out_shape)
+        self.output_projector.build(out_shape)
 
         # Choose coefficient according to [2] Section 3.3
         self._c_huber = 0.00054 * ops.sqrt(xz_shape[-1])

--- a/bayesflow/networks/inference/consistency/consistency_model.py
+++ b/bayesflow/networks/inference/consistency/consistency_model.py
@@ -202,7 +202,11 @@ class ConsistencyModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if getattr(self.subnet, "projects_output", False):
+        # construct input shape for subnet and subnet projector
+        time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
+        self.subnet.build((xz_shape, time_shape, conditions_shape))
+        out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
+        if out_shape[-1] == xz_shape[-1]:
             # subnet already outputs in target space
             self.output_projector = keras.layers.Identity()
         else:
@@ -211,11 +215,6 @@ class ConsistencyModel(InferenceNetwork):
                 bias_initializer="zeros",
                 name="output_projector",
             )
-
-        # construct input shape for subnet and subnet projector
-        time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
-        self.subnet.build((xz_shape, time_shape, conditions_shape))
-        out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
         self.output_projector.build(out_shape)
 
         # Choose coefficient according to [2] Section 3.3

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -68,10 +68,6 @@ class StableConsistencyModel(InferenceNetwork):
     weight_mlp_kwargs : dict[str, any], optional
         Keyword arguments for an auxiliary MLP used to generate weights within the
         consistency model (e.g., depth, hidden sizes, non-linearity choices).
-    subnet_projector : keras.layers.Layer, optional
-        The subnet projector is applied to the subnet output. Default is a dense layer to map
-        the subnets output to the inference variable dimension.
-        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``
         (e.g., ``name``, ``dtype``, or ``trainable``).
@@ -103,7 +99,6 @@ class StableConsistencyModel(InferenceNetwork):
         rho: float = 3.5,
         subnet_kwargs: dict[str, any] = None,
         weight_mlp_kwargs: dict[str, any] = None,
-        subnet_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution="normal", **kwargs)
@@ -116,12 +111,7 @@ class StableConsistencyModel(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        if subnet_projector is not None:
-            self.subnet_projector = subnet_projector
-        elif subnet == "diffusion_transformer":
-            self.subnet_projector = keras.layers.Identity()
-        else:
-            self.subnet_projector = None  # defaults to a dense layer
+        self.subnet_projector = None
 
         weight_mlp_kwargs = weight_mlp_kwargs or {}
         weight_mlp_kwargs = WEIGHT_MLP_DEFAULTS | weight_mlp_kwargs
@@ -157,7 +147,6 @@ class StableConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "subnet_projector": self.subnet_projector,
         }
 
         return base_config | serialize(config)
@@ -181,7 +170,10 @@ class StableConsistencyModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if self.subnet_projector is None:
+        if getattr(self.subnet, "projects_output", False):
+            # subnet already outputs in target space
+            self.subnet_projector = keras.layers.Identity()
+        else:
             self.subnet_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",
@@ -192,8 +184,7 @@ class StableConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         input_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if not self.subnet_projector.built:
-            self.subnet_projector.build(input_shape)
+        self.subnet_projector.build(input_shape)
 
         # input shape for weight function and projector
         input_shape = (xz_shape[0], 1)

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -170,7 +170,11 @@ class StableConsistencyModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if getattr(self.subnet, "projects_output", False):
+        # construct input shape for subnet and subnet projector
+        time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
+        self.subnet.build((xz_shape, time_shape, conditions_shape))
+        out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
+        if out_shape[-1] == xz_shape[-1]:
             # subnet already outputs in target space
             self.subnet_projector = keras.layers.Identity()
         else:
@@ -179,12 +183,7 @@ class StableConsistencyModel(InferenceNetwork):
                 bias_initializer="zeros",
                 name="subnet_projector",
             )
-
-        # construct input shape for subnet and subnet projector
-        time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
-        self.subnet.build((xz_shape, time_shape, conditions_shape))
-        input_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        self.subnet_projector.build(input_shape)
+        self.subnet_projector.build(out_shape)
 
         # input shape for weight function and projector
         input_shape = (xz_shape[0], 1)

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -112,6 +112,7 @@ class StableConsistencyModel(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.subnet_projector = None
+        self._project_output = kwargs.pop("project_output", None)
 
         weight_mlp_kwargs = weight_mlp_kwargs or {}
         weight_mlp_kwargs = WEIGHT_MLP_DEFAULTS | weight_mlp_kwargs
@@ -147,9 +148,15 @@ class StableConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "project_output": self._project_output,
         }
 
         return base_config | serialize(config)
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        # Older configs may have no "project_output" key and always used a Dense projector.
+        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     @staticmethod
     def _discretize_time(num_steps: int, rho: float):
@@ -174,15 +181,17 @@ class StableConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if out_shape[-1] == xz_shape[-1]:
-            # subnet already outputs in target space
-            self.subnet_projector = keras.layers.Identity()
-        else:
+        if self._project_output is None:
+            # a subnet whose output already has the target width projects into target space itself
+            self._project_output = out_shape[-1] != xz_shape[-1]
+        if self._project_output:
             self.subnet_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",
                 name="subnet_projector",
             )
+        else:
+            self.subnet_projector = keras.layers.Identity()
         self.subnet_projector.build(out_shape)
 
         # input shape for weight function and projector

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -112,7 +112,6 @@ class StableConsistencyModel(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.subnet_projector = None
-        self._project_output = kwargs.pop("project_output", None)
 
         weight_mlp_kwargs = weight_mlp_kwargs or {}
         weight_mlp_kwargs = WEIGHT_MLP_DEFAULTS | weight_mlp_kwargs
@@ -148,15 +147,9 @@ class StableConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "project_output": self._project_output,
         }
 
         return base_config | serialize(config)
-
-    @classmethod
-    def from_config(cls, config, custom_objects=None):
-        # Older configs may have no "project_output" key and always used a Dense projector.
-        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     @staticmethod
     def _discretize_time(num_steps: int, rho: float):
@@ -181,10 +174,7 @@ class StableConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if self._project_output is None:
-            # a subnet whose output already has the target width projects into target space itself
-            self._project_output = out_shape[-1] != xz_shape[-1]
-        if self._project_output:
+        if out_shape[-1] != xz_shape[-1]:
             self.subnet_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -192,7 +192,8 @@ class StableConsistencyModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         input_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        self.subnet_projector.build(input_shape)
+        if not self.subnet_projector.built:
+            self.subnet_projector.build(input_shape)
 
         # input shape for weight function and projector
         input_shape = (xz_shape[0], 1)

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -68,6 +68,10 @@ class StableConsistencyModel(InferenceNetwork):
     weight_mlp_kwargs : dict[str, any], optional
         Keyword arguments for an auxiliary MLP used to generate weights within the
         consistency model (e.g., depth, hidden sizes, non-linearity choices).
+    subnet_projector : keras.layers.Layer, optional
+        The subnet projector is applied to the subnet output. Default is a dense layer to map
+        the subnets output to the inference variable dimension.
+        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``
         (e.g., ``name``, ``dtype``, or ``trainable``).
@@ -99,6 +103,7 @@ class StableConsistencyModel(InferenceNetwork):
         rho: float = 3.5,
         subnet_kwargs: dict[str, any] = None,
         weight_mlp_kwargs: dict[str, any] = None,
+        subnet_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution="normal", **kwargs)
@@ -111,7 +116,12 @@ class StableConsistencyModel(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        self.subnet_projector = None
+        if subnet_projector is not None:
+            self.subnet_projector = subnet_projector
+        elif subnet == "diffusion_transformer":
+            self.subnet_projector = keras.layers.Identity()
+        else:
+            self.subnet_projector = None  # defaults to a dense layer
 
         weight_mlp_kwargs = weight_mlp_kwargs or {}
         weight_mlp_kwargs = WEIGHT_MLP_DEFAULTS | weight_mlp_kwargs
@@ -147,6 +157,7 @@ class StableConsistencyModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "subnet_projector": self.subnet_projector,
         }
 
         return base_config | serialize(config)
@@ -170,11 +181,12 @@ class StableConsistencyModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        self.subnet_projector = keras.layers.Dense(
-            units=xz_shape[-1],
-            bias_initializer="zeros",
-            name="output_projector",
-        )
+        if self.subnet_projector is None:
+            self.subnet_projector = keras.layers.Dense(
+                units=xz_shape[-1],
+                bias_initializer="zeros",
+                name="subnet_projector",
+            )
 
         # construct input shape for subnet and subnet projector
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -291,7 +291,8 @@ class DiffusionModel(InferenceNetwork):
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
 
-        self.output_projector.build(out_shape)
+        if not self.output_projector.built:
+            self.output_projector.build(out_shape)
 
     def get_config(self):
         base_config = super().get_config()

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -83,10 +83,6 @@ class DiffusionModel(InferenceNetwork):
         Probability of marking each condition as missing during training, so the network learns
         to handle missing conditions. Only takes effect when the subnet accepts
         ``infer_target_mask`` (e.g. ``diffusion_transformer``). Default is 0.0.
-    output_projector : keras.layers.Layer, optional
-        The output projector is applied to the subnet output. Default is a dense layer to map
-        the subnets output to the inference variable dimension.
-        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``.
 
@@ -125,7 +121,6 @@ class DiffusionModel(InferenceNetwork):
         fixed_target_prob: float = 0.0,
         missing_target_prob: float = 0.0,
         missing_conditions_prob: float = 0.0,
-        output_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution="normal", **kwargs)
@@ -160,12 +155,7 @@ class DiffusionModel(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        if output_projector is not None:
-            self.output_projector = output_projector
-        elif subnet == "diffusion_transformer":
-            self.output_projector = keras.layers.Identity()
-        else:
-            self.output_projector = None  # defaults to a dense layer
+        self.output_projector = None
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -278,7 +268,10 @@ class DiffusionModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if self.output_projector is None:
+        if getattr(self.subnet, "projects_output", False):
+            # subnet already outputs in target space
+            self.output_projector = keras.layers.Identity()
+        else:
             units = 1 if self._prediction_type == "potential" else xz_shape[-1]
             self.output_projector = keras.layers.Dense(
                 units=units,
@@ -291,8 +284,7 @@ class DiffusionModel(InferenceNetwork):
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
 
-        if not self.output_projector.built:
-            self.output_projector.build(out_shape)
+        self.output_projector.build(out_shape)
 
     def get_config(self):
         base_config = super().get_config()
@@ -307,7 +299,6 @@ class DiffusionModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "output_projector": self.output_projector,
         }
         return base_config | serialize(config)
 

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -156,7 +156,6 @@ class DiffusionModel(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.output_projector = None
-        self._project_output = kwargs.pop("project_output", None)
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -275,10 +274,7 @@ class DiffusionModel(InferenceNetwork):
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
 
         units = 1 if self._prediction_type == "potential" else xz_shape[-1]
-        if self._project_output is None:
-            # a subnet whose output already has the target width projects into target space itself
-            self._project_output = out_shape[-1] != units
-        if self._project_output:
+        if out_shape[-1] != units:
             self.output_projector = keras.layers.Dense(
                 units=units,
                 bias_initializer="zeros",
@@ -301,14 +297,8 @@ class DiffusionModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "project_output": self._project_output,
         }
         return base_config | serialize(config)
-
-    @classmethod
-    def from_config(cls, config, custom_objects=None):
-        # Older configs may have no "project_output" key and always used a Dense projector.
-        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     def guidance_function(
         self,

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -268,7 +268,11 @@ class DiffusionModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if getattr(self.subnet, "projects_output", False):
+        # construct input shape for subnet and subnet projector
+        time_shape = (xz_shape[0], 1)
+        self.subnet.build((xz_shape, time_shape, conditions_shape))
+        out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
+        if out_shape[-1] == xz_shape[-1]:
             # subnet already outputs in target space
             self.output_projector = keras.layers.Identity()
         else:
@@ -278,12 +282,6 @@ class DiffusionModel(InferenceNetwork):
                 bias_initializer="zeros",
                 name="output_projector",
             )
-
-        # construct input shape for subnet and subnet projector
-        time_shape = (xz_shape[0], 1)
-        self.subnet.build((xz_shape, time_shape, conditions_shape))
-        out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-
         self.output_projector.build(out_shape)
 
     def get_config(self):

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -156,6 +156,7 @@ class DiffusionModel(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.output_projector = None
+        self._project_output = kwargs.pop("project_output", None)
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -272,16 +273,19 @@ class DiffusionModel(InferenceNetwork):
         time_shape = (xz_shape[0], 1)
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if out_shape[-1] == xz_shape[-1]:
-            # subnet already outputs in target space
-            self.output_projector = keras.layers.Identity()
-        else:
-            units = 1 if self._prediction_type == "potential" else xz_shape[-1]
+
+        units = 1 if self._prediction_type == "potential" else xz_shape[-1]
+        if self._project_output is None:
+            # a subnet whose output already has the target width projects into target space itself
+            self._project_output = out_shape[-1] != units
+        if self._project_output:
             self.output_projector = keras.layers.Dense(
                 units=units,
                 bias_initializer="zeros",
                 name="output_projector",
             )
+        else:
+            self.output_projector = keras.layers.Identity()
         self.output_projector.build(out_shape)
 
     def get_config(self):
@@ -297,8 +301,14 @@ class DiffusionModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "project_output": self._project_output,
         }
         return base_config | serialize(config)
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        # Older configs may have no "project_output" key and always used a Dense projector.
+        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     def guidance_function(
         self,

--- a/bayesflow/networks/inference/diffusion/diffusion_model.py
+++ b/bayesflow/networks/inference/diffusion/diffusion_model.py
@@ -55,8 +55,8 @@ class DiffusionModel(InferenceNetwork):
     subnet : str, type, or keras.Layer
         A neural network type for the diffusion model, will be instantiated using
         *subnet_kwargs*.  If a string is provided, it should be a registered name
-        (e.g., ``"time_mlp"``).  If a type or ``keras.Layer`` is provided, it will
-        be directly instantiated with the given *subnet_kwargs*.  Any subnet must
+        (e.g., ``"time_mlp"``, ``"diffusion_transformer"``).  If a type or ``keras.Layer`` is provided,
+        it will be directly instantiated with the given *subnet_kwargs*.  Any subnet must
         accept a tuple of tensors ``(target, time, conditions)``.
     noise_schedule : {'edm', 'cosine'} or NoiseSchedule or type
         Noise schedule controlling the diffusion dynamics.  Can be a string
@@ -83,6 +83,10 @@ class DiffusionModel(InferenceNetwork):
         Probability of marking each condition as missing during training, so the network learns
         to handle missing conditions. Only takes effect when the subnet accepts
         ``infer_target_mask`` (e.g. ``diffusion_transformer``). Default is 0.0.
+    output_projector : keras.layers.Layer, optional
+        The output projector is applied to the subnet output. Default is a dense layer to map
+        the subnets output to the inference variable dimension.
+        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``.
 
@@ -121,6 +125,7 @@ class DiffusionModel(InferenceNetwork):
         fixed_target_prob: float = 0.0,
         missing_target_prob: float = 0.0,
         missing_conditions_prob: float = 0.0,
+        output_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution="normal", **kwargs)
@@ -155,7 +160,12 @@ class DiffusionModel(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        self.output_projector = None
+        if output_projector is not None:
+            self.output_projector = output_projector
+        elif subnet == "diffusion_transformer":
+            self.output_projector = keras.layers.Identity()
+        else:
+            self.output_projector = None  # defaults to a dense layer
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -268,8 +278,13 @@ class DiffusionModel(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        units = 1 if self._prediction_type == "potential" else xz_shape[-1]
-        self.output_projector = keras.layers.Dense(units=units, bias_initializer="zeros")
+        if self.output_projector is None:
+            units = 1 if self._prediction_type == "potential" else xz_shape[-1]
+            self.output_projector = keras.layers.Dense(
+                units=units,
+                bias_initializer="zeros",
+                name="output_projector",
+            )
 
         # construct input shape for subnet and subnet projector
         time_shape = (xz_shape[0], 1)
@@ -291,6 +306,7 @@ class DiffusionModel(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "output_projector": self.output_projector,
         }
         return base_config | serialize(config)
 

--- a/bayesflow/networks/inference/flow_matching/flow_matching.py
+++ b/bayesflow/networks/inference/flow_matching/flow_matching.py
@@ -149,7 +149,6 @@ class FlowMatching(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.output_projector = None
-        self._project_output = kwargs.pop("project_output", None)
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -225,10 +224,7 @@ class FlowMatching(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if self._project_output is None:
-            # a subnet whose output already has the target width projects into target space itself
-            self._project_output = out_shape[-1] != xz_shape[-1]
-        if self._project_output:
+        if out_shape[-1] != xz_shape[-1]:
             self.output_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",
@@ -253,16 +249,10 @@ class FlowMatching(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "project_output": self._project_output,
             # we do not need to store subnet_kwargs
         }
 
         return base_config | serialize(config)
-
-    @classmethod
-    def from_config(cls, config, custom_objects=None):
-        # Older configs may have no "project_output" key and always used a Dense projector.
-        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     def velocity(
         self, xz: Tensor, time: float | Tensor, conditions: Tensor = None, training: bool = False, **kwargs

--- a/bayesflow/networks/inference/flow_matching/flow_matching.py
+++ b/bayesflow/networks/inference/flow_matching/flow_matching.py
@@ -220,7 +220,11 @@ class FlowMatching(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if getattr(self.subnet, "projects_output", False):
+        # construct input shape for subnet and subnet projector
+        time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
+        self.subnet.build((xz_shape, time_shape, conditions_shape))
+        out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
+        if out_shape[-1] == xz_shape[-1]:
             # subnet already outputs in target space
             self.output_projector = keras.layers.Identity()
         else:
@@ -229,12 +233,6 @@ class FlowMatching(InferenceNetwork):
                 bias_initializer="zeros",
                 name="output_projector",
             )
-
-        # construct input shape for subnet and subnet projector
-        time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
-        self.subnet.build((xz_shape, time_shape, conditions_shape))
-        out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-
         self.output_projector.build(out_shape)
 
     def get_config(self):

--- a/bayesflow/networks/inference/flow_matching/flow_matching.py
+++ b/bayesflow/networks/inference/flow_matching/flow_matching.py
@@ -81,10 +81,6 @@ class FlowMatching(InferenceNetwork):
         Probability of marking each condition as missing during training, so the network learns
         to handle missing conditions. Only takes effect when the subnet accepts
         ``infer_target_mask`` (e.g. ``diffusion_transformer``). Default is 0.0.
-    output_projector : keras.layers.Layer, optional
-        The output projector is applied to the subnet output. Default is a dense layer to map
-        the subnets output to the inference variable dimension.
-        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``.
 
@@ -128,7 +124,6 @@ class FlowMatching(InferenceNetwork):
         fixed_target_prob: float = 0.0,
         missing_target_prob: float = 0.0,
         missing_conditions_prob: float = 0.0,
-        output_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution, **kwargs)
@@ -153,12 +148,7 @@ class FlowMatching(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        if output_projector is not None:
-            self.output_projector = output_projector
-        elif subnet == "diffusion_transformer":
-            self.output_projector = keras.layers.Identity()
-        else:
-            self.output_projector = None  # defaults to a dense layer
+        self.output_projector = None
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -230,7 +220,10 @@ class FlowMatching(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        if self.output_projector is None:
+        if getattr(self.subnet, "projects_output", False):
+            # subnet already outputs in target space
+            self.output_projector = keras.layers.Identity()
+        else:
             self.output_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",
@@ -242,8 +235,7 @@ class FlowMatching(InferenceNetwork):
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
 
-        if not self.output_projector.built:
-            self.output_projector.build(out_shape)
+        self.output_projector.build(out_shape)
 
     def get_config(self):
         base_config = super().get_config()
@@ -260,7 +252,6 @@ class FlowMatching(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
-            "output_projector": self.output_projector,
             # we do not need to store subnet_kwargs
         }
 

--- a/bayesflow/networks/inference/flow_matching/flow_matching.py
+++ b/bayesflow/networks/inference/flow_matching/flow_matching.py
@@ -242,7 +242,8 @@ class FlowMatching(InferenceNetwork):
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
 
-        self.output_projector.build(out_shape)
+        if not self.output_projector.built:
+            self.output_projector.build(out_shape)
 
     def get_config(self):
         base_config = super().get_config()

--- a/bayesflow/networks/inference/flow_matching/flow_matching.py
+++ b/bayesflow/networks/inference/flow_matching/flow_matching.py
@@ -149,6 +149,7 @@ class FlowMatching(InferenceNetwork):
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
         self.output_projector = None
+        self._project_output = kwargs.pop("project_output", None)
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -224,15 +225,17 @@ class FlowMatching(InferenceNetwork):
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
         self.subnet.build((xz_shape, time_shape, conditions_shape))
         out_shape = self.subnet.compute_output_shape((xz_shape, time_shape, conditions_shape))
-        if out_shape[-1] == xz_shape[-1]:
-            # subnet already outputs in target space
-            self.output_projector = keras.layers.Identity()
-        else:
+        if self._project_output is None:
+            # a subnet whose output already has the target width projects into target space itself
+            self._project_output = out_shape[-1] != xz_shape[-1]
+        if self._project_output:
             self.output_projector = keras.layers.Dense(
                 units=xz_shape[-1],
                 bias_initializer="zeros",
                 name="output_projector",
             )
+        else:
+            self.output_projector = keras.layers.Identity()
         self.output_projector.build(out_shape)
 
     def get_config(self):
@@ -250,10 +253,16 @@ class FlowMatching(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "project_output": self._project_output,
             # we do not need to store subnet_kwargs
         }
 
         return base_config | serialize(config)
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        # Older configs may have no "project_output" key and always used a Dense projector.
+        return super().from_config({"project_output": True} | config, custom_objects=custom_objects)
 
     def velocity(
         self, xz: Tensor, time: float | Tensor, conditions: Tensor = None, training: bool = False, **kwargs

--- a/bayesflow/networks/inference/flow_matching/flow_matching.py
+++ b/bayesflow/networks/inference/flow_matching/flow_matching.py
@@ -81,6 +81,10 @@ class FlowMatching(InferenceNetwork):
         Probability of marking each condition as missing during training, so the network learns
         to handle missing conditions. Only takes effect when the subnet accepts
         ``infer_target_mask`` (e.g. ``diffusion_transformer``). Default is 0.0.
+    output_projector : keras.layers.Layer, optional
+        The output projector is applied to the subnet output. Default is a dense layer to map
+        the subnets output to the inference variable dimension.
+        Projector is omitted for ``"diffusion_transformer"``.
     **kwargs
         Additional keyword arguments passed to the base ``InferenceNetwork``.
 
@@ -124,6 +128,7 @@ class FlowMatching(InferenceNetwork):
         fixed_target_prob: float = 0.0,
         missing_target_prob: float = 0.0,
         missing_conditions_prob: float = 0.0,
+        output_projector: keras.Layer = None,
         **kwargs,
     ):
         super().__init__(base_distribution, **kwargs)
@@ -148,7 +153,12 @@ class FlowMatching(InferenceNetwork):
         self.subnet = find_network(subnet, **subnet_kwargs)
         self._subnet_mask_keys = set(filter_kwargs({k: None for k in self._SUBNET_MASK_KEYS}, self.subnet.call).keys())
 
-        self.output_projector = None
+        if output_projector is not None:
+            self.output_projector = output_projector
+        elif subnet == "diffusion_transformer":
+            self.output_projector = keras.layers.Identity()
+        else:
+            self.output_projector = None  # defaults to a dense layer
         self.fixed_target_prob = fixed_target_prob
         self.missing_target_prob = missing_target_prob
         self.missing_conditions_prob = missing_conditions_prob
@@ -220,11 +230,12 @@ class FlowMatching(InferenceNetwork):
 
         self.base_distribution.build(xz_shape)
 
-        self.output_projector = keras.layers.Dense(
-            units=xz_shape[-1],
-            bias_initializer="zeros",
-            name="output_projector",
-        )
+        if self.output_projector is None:
+            self.output_projector = keras.layers.Dense(
+                units=xz_shape[-1],
+                bias_initializer="zeros",
+                name="output_projector",
+            )
 
         # construct input shape for subnet and subnet projector
         time_shape = (xz_shape[0], 1)  # same batch dims, 1 feature
@@ -248,6 +259,7 @@ class FlowMatching(InferenceNetwork):
             "fixed_target_prob": self.fixed_target_prob,
             "missing_target_prob": self.missing_target_prob,
             "missing_conditions_prob": self.missing_conditions_prob,
+            "output_projector": self.output_projector,
             # we do not need to store subnet_kwargs
         }
 

--- a/bayesflow/networks/subnets/transformer/diffusion_transformer.py
+++ b/bayesflow/networks/subnets/transformer/diffusion_transformer.py
@@ -67,9 +67,6 @@ class DiffusionTransformer(keras.Layer):
         Additional keyword arguments forwarded to ``keras.Layer``.
     """
 
-    # The final token projection already maps into target space, so no output projector is needed.
-    projects_output = True
-
     # Condition-state embedding indices for the learnable state table.
     _STATE_LATENT = 0  # target token being inferred (noised)
     _STATE_OBSERVED = 1  # clean target conditioned upon, or present condition

--- a/bayesflow/networks/subnets/transformer/diffusion_transformer.py
+++ b/bayesflow/networks/subnets/transformer/diffusion_transformer.py
@@ -67,6 +67,9 @@ class DiffusionTransformer(keras.Layer):
         Additional keyword arguments forwarded to ``keras.Layer``.
     """
 
+    # The final token projection already maps into target space, so no output projector is needed.
+    projects_output = True
+
     # Condition-state embedding indices for the learnable state table.
     _STATE_LATENT = 0  # target token being inferred (noised)
     _STATE_OBSERVED = 1  # clean target conditioned upon, or present condition


### PR DESCRIPTION
The output projection layer was incompatible with the transformer backbone in the diffusion type models when employed together with masking of targets. I added an optional `output_projector` parameter to the constructors of these models, allowing users to specify a custom output projection layer. If not provided, a default dense layer is used as before, except when the subnet is a `"diffusion_transformer"`, in which case an identity layer is used.