### PR TITLE
Improve adaptive solvers for density computation

### DIFF
--- a/bayesflow/approximators/helpers/compositional.py
+++ b/bayesflow/approximators/helpers/compositional.py
@@ -50,27 +50,14 @@ def build_prior_score_fn(
     else:
         std_expanded = None
 
-    def _step(samples: Tensor, time: Tensor) -> Tensor:
-        samples = keras.tree.map_structure(
-            lambda s: standardizer.maybe_standardize(s, key="inference_variables", stage="inference", forward=False),
-            samples,
-        )
+    def _adapter_prior_score(samples: Tensor, time: Tensor) -> Tensor:
+        """Numpy-based part (adapter inverse + user prior score), must run eagerly."""
+        if keras.backend.backend() == "torch":  # adapter cannot use torch tensors
+            samples = keras.ops.convert_to_numpy(samples)
 
-        if keras.backend.backend() != "torch":  # samples cannot be converted to numpy, otherwise it breaks
-            adapted_samples, log_det_jac = keras.tree.map_structure(
-                lambda s: adapter({"inference_variables": s}, inverse=True, strict=False, log_det_jac=True),
-                samples,
-            )
-        else:  # samples need to be converted to numpy, adapter cannot use torch tensors
-            adapted_samples, log_det_jac = keras.tree.map_structure(
-                lambda s: adapter(
-                    {"inference_variables": keras.ops.convert_to_numpy(s)},
-                    inverse=True,
-                    strict=False,
-                    log_det_jac=True,
-                ),
-                samples,
-            )
+        adapted_samples, log_det_jac = adapter(
+            {"inference_variables": samples}, inverse=True, strict=False, log_det_jac=True
+        )
 
         if len(log_det_jac) > 0:
             problematic_keys = [key for key in log_det_jac if log_det_jac[key] != 0.0]
@@ -87,7 +74,25 @@ def build_prior_score_fn(
         for key in adapted_samples:
             prior_score[key] = keras.ops.cast(prior_score[key], "float32")
         prior_score = keras.tree.map_structure(keras.ops.convert_to_tensor, prior_score)
-        out = keras.ops.concatenate([prior_score[key] for key in adapted_samples], axis=-1)
+        return keras.ops.concatenate([prior_score[key] for key in adapted_samples], axis=-1)
+
+    def _step(samples: Tensor, time: Tensor) -> Tensor:
+        samples = keras.tree.map_structure(
+            lambda s: standardizer.maybe_standardize(s, key="inference_variables", stage="inference", forward=False),
+            samples,
+        )
+
+        if keras.backend.backend() == "tensorflow":
+            import tensorflow as tf
+
+            if tf.executing_eagerly():
+                out = _adapter_prior_score(samples, time)
+            else:
+                # tracing inside tf.function, run the numpy-based adapter and prior score eagerly
+                out = tf.py_function(_adapter_prior_score, inp=[samples, time], Tout=tf.float32)
+                out.set_shape(samples.shape)
+        else:
+            out = _adapter_prior_score(samples, time)
 
         if not prior_has_time:
             out = (1 - time) * out

--- a/bayesflow/networks/inference/consistency/stable_consistency_model.py
+++ b/bayesflow/networks/inference/consistency/stable_consistency_model.py
@@ -153,11 +153,11 @@ class StableConsistencyModel(InferenceNetwork):
 
     @staticmethod
     def _discretize_time(num_steps: int, rho: float):
-        t = keras.ops.linspace(0.0, pi / 2, num_steps)
+        t = keras.ops.linspace(0.0, pi / 2, num_steps + 1)[1:]
         times = keras.ops.exp((t - pi / 2) * rho) * pi / 2
 
         # if rho is set too low, bad schedules can occur
-        if times[1] > StableConsistencyModel.EPS_WARN:
+        if times[0] > StableConsistencyModel.EPS_WARN:
             logging.warning("Warning: The last time step is large.")
             logging.warning(f"Increasing rho (was {rho}) or n_steps (was {num_steps}) might improve results.")
         return times

--- a/bayesflow/utils/integrate.py
+++ b/bayesflow/utils/integrate.py
@@ -54,6 +54,45 @@ def add_scaled(state, ks, coeffs, h):
     return out
 
 
+def _error_ratio(
+    err_state: StateDict,
+    state: StateDict,
+    new_state: StateDict,
+    atol: ArrayLike,
+    rtol: ArrayLike,
+) -> ArrayLike:
+    """Normalize a local error estimate by a per-component tolerance.
+
+    The error of an entry is reduced with a root-mean-square norm, which keeps the criterion independent of
+    the number of components.
+
+    Parameters
+    ----------
+    err_state : dict
+        Local error estimate per state entry, as returned by the adaptive step functions.
+    state : dict
+        State at the beginning of the step.
+    new_state : dict
+        State at the end of the step.
+    atol : int or float or Tensor
+        Absolute tolerance.
+    rtol : int or float or Tensor
+        Relative tolerance.
+
+    Returns
+    -------
+    int or float or Tensor
+        The normalized error, which is at most 1 if the step meets the requested tolerance.
+    """
+    ratio = None
+    for key, err in err_state.items():
+        scale = atol + rtol * keras.ops.maximum(keras.ops.abs(state[key]), keras.ops.abs(new_state[key]))
+        key_ratio = keras.ops.max(keras.ops.sqrt(keras.ops.mean(keras.ops.square(err / scale), axis=-1)))
+        ratio = key_ratio if ratio is None else keras.ops.maximum(ratio, key_ratio)
+
+    return ratio
+
+
 def rk45_step(
     fn: Callable,
     state: StateDict,
@@ -61,7 +100,7 @@ def rk45_step(
     step_size: ArrayLike,
     k1: StateDict = None,
     use_adaptive_step_size: bool = True,
-) -> Tuple[StateDict, ArrayLike, StateDict | None, ArrayLike]:
+) -> Tuple[StateDict, ArrayLike, StateDict | None, StateDict | None]:
     """
     Dormand-Prince 5(4) method with embedded error estimation [1].
 
@@ -97,7 +136,7 @@ def rk45_step(
 
     new_time = time + h
     if not use_adaptive_step_size:
-        return new_state, new_time, None, 0.0
+        return new_state, new_time, None, None
 
     k7 = fn(time + h, **filter_kwargs(new_state, fn))
 
@@ -114,10 +153,7 @@ def rk45_step(
         )
         err_state[key] = new_state[key] - y4
 
-    err_norm = keras.ops.stack([keras.ops.norm(v, ord=2, axis=-1) for v in err_state.values()])
-    err = keras.ops.max(err_norm)
-
-    return new_state, new_time, k7, err
+    return new_state, new_time, k7, err_state
 
 
 def tsit5_step(
@@ -127,7 +163,7 @@ def tsit5_step(
     step_size: ArrayLike,
     k1: StateDict = None,
     use_adaptive_step_size: bool = True,
-) -> Tuple[StateDict, ArrayLike, StateDict | None, ArrayLike]:
+) -> Tuple[StateDict, ArrayLike, StateDict | None, StateDict | None]:
     """
     Implements a single step of the Tsitouras 5/4 Runge-Kutta method [1].
 
@@ -192,7 +228,7 @@ def tsit5_step(
 
     new_time = time + h
     if not use_adaptive_step_size:
-        return new_state, new_time, None, 0.0
+        return new_state, new_time, None, None
 
     k7 = fn(time + h, **filter_kwargs(new_state, fn))
 
@@ -208,10 +244,7 @@ def tsit5_step(
             - 0.45808210592918697 * k6[key]
         )
 
-    err_norm = keras.ops.stack([keras.ops.norm(v, ord=2, axis=-1) for v in err_state.values()])
-    err = keras.ops.max(err_norm)
-
-    return new_state, new_time, k7, err
+    return new_state, new_time, k7, err_state
 
 
 def integrate_fixed(
@@ -313,8 +346,9 @@ def integrate_adaptive(
         case other:
             raise TypeError(f"Invalid integration method: {other!r}")
 
-    atol = keras.ops.convert_to_tensor(kwargs.get("atol", 1e-6), dtype="float32")
-    rtol = keras.ops.convert_to_tensor(kwargs.get("rtol", 1e-4), dtype="float32")
+    # density computation needs higher accuracy, reduce tolerances
+    atol = keras.ops.convert_to_tensor(kwargs.get("atol", 1e-6 if len(state) == 1 else 1e-8), dtype="float32")
+    rtol = keras.ops.convert_to_tensor(kwargs.get("rtol", 1e-4 if len(state) == 1 else 1e-8), dtype="float32")
     initial_step = keras.ops.convert_to_tensor((stop_time - start_time) / float(min_steps), dtype="float32")
     step0 = keras.ops.convert_to_tensor(0.0, dtype="float32")
     count_not_accepted = 0
@@ -342,7 +376,7 @@ def integrate_adaptive(
         h = keras.ops.sign(_step_size) * keras.ops.clip(keras.ops.abs(_step_size), min_step_size, max_step_size)
 
         # Take one trial step
-        new_state, new_time, new_k1, err = step_fn(
+        new_state, new_time, new_k1, err_state = step_fn(
             state=_state,
             time=_time,
             step_size=h,
@@ -350,12 +384,7 @@ def integrate_adaptive(
         )
 
         # New step size suggestion
-        max_abs = None
-        for k, v in _state.items():
-            m = keras.ops.max(keras.ops.abs(v))
-            max_abs = m if max_abs is None else keras.ops.maximum(max_abs, m)
-        scale = atol + rtol * max_abs
-        error_ratio = err / scale
+        error_ratio = _error_ratio(err_state, _state, new_state, atol, rtol)
         new_step_size = h * keras.ops.clip(0.9 * (1.0 / (error_ratio + 1e-12)) ** 0.2, 0.2, 5.0)
         new_step_size = keras.ops.sign(new_step_size) * keras.ops.clip(
             keras.ops.abs(new_step_size), min_step_size, max_step_size

--- a/bayesflow/utils/integrate.py
+++ b/bayesflow/utils/integrate.py
@@ -28,6 +28,15 @@ def _check_all_nans(state: StateDict):
     return keras.ops.all(keras.ops.stack(all_nans_flags))
 
 
+def _as_concrete_bool(x) -> bool | None:
+    """Return ``bool(x)`` if `x` holds a concrete value, or None if `x` is symbolic,
+    e.g. while tracing inside ``tf.function`` or ``jax.jit``."""
+    try:
+        return bool(x)
+    except Exception:
+        return None
+
+
 def euler_step(
     fn: Callable,
     state: StateDict,
@@ -294,6 +303,8 @@ def integrate_scheduled(
     method: str,
     **kwargs,
 ) -> StateDict:
+    steps = keras.ops.convert_to_tensor(steps, dtype=keras.config.floatx())
+
     match method:
         case "euler":
             step_fn = partial(euler_step, fn, **filter_kwargs(kwargs, euler_step))
@@ -346,12 +357,12 @@ def integrate_adaptive(
         case other:
             raise TypeError(f"Invalid integration method: {other!r}")
 
-    # density computation needs higher accuracy, reduce tolerances
-    atol = keras.ops.convert_to_tensor(kwargs.get("atol", 1e-6 if len(state) == 1 else 1e-8), dtype="float32")
-    rtol = keras.ops.convert_to_tensor(kwargs.get("rtol", 1e-4 if len(state) == 1 else 1e-8), dtype="float32")
+    # density computation (state carries more than one entry) needs higher accuracy than sampling,
+    atol = keras.ops.convert_to_tensor(kwargs.get("atol", 1e-6), dtype="float32")
+    rtol = keras.ops.convert_to_tensor(kwargs.get("rtol", 1e-4 if len(state) == 1 else 1e-5), dtype="float32")
     initial_step = keras.ops.convert_to_tensor((stop_time - start_time) / float(min_steps), dtype="float32")
     step0 = keras.ops.convert_to_tensor(0.0, dtype="float32")
-    count_not_accepted = 0
+    count_not_accepted = keras.ops.convert_to_tensor(0.0, dtype="float32")
 
     # "First Same As Last" (FSAL) property
     k1_0 = fn(start_time, **filter_kwargs(state, fn))
@@ -391,12 +402,15 @@ def integrate_adaptive(
         )
 
         # Error control
-        too_big = keras.ops.greater(error_ratio, 1.0)
+        within_tol = keras.ops.logical_or(
+            keras.ops.less_equal(error_ratio, 1.0),
+            keras.ops.isnan(error_ratio),
+        )
         at_min = keras.ops.less_equal(
             keras.ops.abs(h),
             keras.ops.abs(min_step_size),
         )
-        accepted = keras.ops.logical_or(keras.ops.logical_not(too_big), at_min)
+        accepted = keras.ops.logical_or(within_tol, at_min)
 
         updated_state = keras.ops.cond(accepted, lambda: new_state, lambda: _state)
         updated_time = keras.ops.cond(accepted, lambda: new_time, lambda: _time)
@@ -414,24 +428,32 @@ def integrate_adaptive(
         cond,
         body,
         [state, start_time, initial_step, step0, k1_0, count_not_accepted],
+        # never reached in normal operation and only guards against non-terminating loops (e.g. NaN pathologies)
+        maximum_iterations=10 * max_steps,
     )
 
-    if _check_all_nans(state):
+    # skipped while tracing (symbolic tensors have no concrete bool)
+    all_nans = _as_concrete_bool(_check_all_nans(state))
+    if all_nans:
         raise RuntimeError(f"All values are NaNs in state during integration at {time}.")
 
     # Final step to hit stop_time exactly
     time_diff = stop_time - time
     time_remaining = keras.ops.sign(stop_time - start_time) * time_diff
-    if keras.ops.all(time_remaining > 0):
-        state, time, _, _ = step_fn(
+
+    def take_final_step():
+        final_state, _, _, _ = step_fn(
             state=state,
             time=time,
             step_size=time_diff,
             k1=k1,
         )
-        step = step + 1.0
+        return final_state, step + 1.0
 
-    debug(f"Finished integration after {step} steps with {count_not_accepted} rejected steps.")
+    state, step = keras.ops.cond(keras.ops.all(time_remaining > 0), take_final_step, lambda: (state, step))
+
+    if all_nans is not None:  # not tracing, values are concrete
+        debug(f"Finished integration after {step} steps with {count_not_accepted} rejected steps.")
     return state
 
 
@@ -481,6 +503,24 @@ def integrate_scipy(
     return result
 
 
+def _compile_loop_integrator(func: Callable) -> Callable:
+    """On the TensorFlow backend, wrap an integration call in ``tf.function``.
+
+    TensorFlow executes ``keras.ops.while_loop``/``fori_loop`` eagerly, one Python
+    iteration per solver step. Tracing the whole integration once removes the per-step
+    Python and GradientTape overhead.
+    """
+    if keras.backend.backend() != "tensorflow":
+        return func
+
+    import tensorflow as tf
+
+    if not tf.executing_eagerly():
+        return func
+
+    return tf.function(func, autograph=False)
+
+
 def integrate(
     fn: Callable,
     state: StateDict,
@@ -492,6 +532,8 @@ def integrate(
     method: str = "rk45",
     **kwargs,
 ) -> StateDict:
+    if isinstance(steps, str) and steps not in ["adaptive", "dynamic"]:
+        raise ValueError(f"Unknown steps value: {steps!r}. Use an integer, an array of times, or 'adaptive'.")
     if isinstance(steps, str) and steps in ["adaptive", "dynamic"]:
         if start_time is None or stop_time is None:
             raise ValueError(
@@ -499,21 +541,37 @@ def integrate(
                 f"'start_time={start_time}', 'stop_time={stop_time}'."
             )
         if method == "scipy":
-            if min_steps != 10:
+            if min_steps != 50:
                 warning("Setting min_steps has no effect for method 'scipy'")
             if max_steps != 10_000:
                 warning("Setting max_steps has no effect for method 'scipy'")
-            return integrate_scipy(fn, state, start_time, stop_time)
-        return integrate_adaptive(fn, state, start_time, stop_time, min_steps, max_steps, method, **kwargs)
+            return integrate_scipy(fn, state, start_time, stop_time, scipy_kwargs=kwargs.get("scipy_kwargs"))
+
+        def run():
+            return integrate_adaptive(fn, state, start_time, stop_time, min_steps, max_steps, method, **kwargs)
+
+        result = _compile_loop_integrator(run)()
+        # covers the TensorFlow backend, where the check inside integrate_adaptive is skipped while tracing
+        if _as_concrete_bool(_check_all_nans(result)):
+            raise RuntimeError("All values are NaNs in state during integration.")
+        return result
     elif isinstance(steps, int):
         if start_time is None or stop_time is None:
             raise ValueError(
                 "Please provide start_time and stop_time for the integration, was "
                 f"'start_time={start_time}', 'stop_time={stop_time}'."
             )
-        return integrate_fixed(fn, state, start_time, stop_time, steps, method, **kwargs)
+
+        def run():
+            return integrate_fixed(fn, state, start_time, stop_time, steps, method, **kwargs)
+
+        return _compile_loop_integrator(run)()
     elif isinstance(steps, Sequence) or isinstance(steps, np.ndarray) or keras.ops.is_tensor(steps):
-        return integrate_scheduled(fn, state, steps, method, **kwargs)
+
+        def run():
+            return integrate_scheduled(fn, state, steps, method, **kwargs)
+
+        return _compile_loop_integrator(run)()
     else:
         raise RuntimeError(f"Type or value of `steps` not understood (steps={steps})")
 
@@ -1069,7 +1127,8 @@ def integrate_stochastic_fixed(
         body,
         [0, state, start_time, initial_step],
     )
-    if _check_all_nans(final_state):
+    # skipped while tracing
+    if _as_concrete_bool(_check_all_nans(final_state)):
         raise RuntimeError(f"All values are NaNs in state during integration at {final_time}.")
 
     return final_state
@@ -1099,8 +1158,7 @@ def integrate_stochastic_adaptive(
     initial_loop_state = (keras.ops.zeros((), dtype="int32"), state, start_time, initial_step, state)
     if keras.backend.backend() == "jax":
         seed = None  # not needed, noise is generated upfront
-    else:
-        seed_body = seed
+    seed_body = seed
 
     def cond(i, current_state, current_time, current_step, last_state):
         time_remaining = keras.ops.sign(stop_time - start_time) * (stop_time - (current_time + current_step))
@@ -1161,13 +1219,15 @@ def integrate_stochastic_adaptive(
     # Execute the adaptive loop
     final_counter, final_state, final_time, _, final_k1 = keras.ops.while_loop(cond, body_adaptive, initial_loop_state)
 
-    if _check_all_nans(final_state):
+    # skipped while tracing
+    if _as_concrete_bool(_check_all_nans(final_state)):
         raise RuntimeError(f"All values are NaNs in state during integration at {final_time}.")
 
     # Final step to hit stop_time exactly
     time_diff = stop_time - final_time
     time_remaining = keras.ops.sign(stop_time - start_time) * time_diff
-    if keras.ops.all(time_remaining > 0):
+
+    def take_final_step():
         noise_final = generate_noise(final_state, seed=seed)
         noise_extra_final = None
         if z_extra_history is not None and len(z_extra_history) > 0:
@@ -1177,7 +1237,7 @@ def integrate_stochastic_adaptive(
             noise_aux=noise_extra_final,
             last_state=final_k1,
         )
-        final_state, _, _ = step_fn(
+        stepped_state, _, _ = step_fn(
             state=final_state,
             time=final_time,
             step_size=time_diff,
@@ -1187,9 +1247,20 @@ def integrate_stochastic_adaptive(
             use_adaptive_step_size=False,
             **filter_kwargs(step_fn_additional_args_final, step_fn),
         )
-        final_counter = final_counter + 1
+        return stepped_state, final_counter + 1
 
-    debug(f"Finished integration after {final_counter}.")
+    take_final = _as_concrete_bool(keras.ops.all(time_remaining > 0))
+    if take_final is None:
+        # tracing inside tf.function: express the branch in-graph. On eager backends the Python
+        # branch below is kept instead, since jax.lax.cond would trace the noise generation
+        final_state, final_counter = keras.ops.cond(
+            keras.ops.all(time_remaining > 0), take_final_step, lambda: (final_state, final_counter)
+        )
+    elif take_final:
+        final_state, final_counter = take_final_step()
+
+    if take_final is not None:  # not tracing, values are concrete
+        debug(f"Finished integration after {final_counter}.")
     return final_state
 
 
@@ -1275,7 +1346,8 @@ def integrate_langevin(
         body,
         (0, state, start_time),
     )
-    if _check_all_nans(final_state):
+    # skipped while tracing
+    if _as_concrete_bool(_check_all_nans(final_state)):
         raise RuntimeError(f"All values are NaNs in state during integration at {final_time}.")
     return final_state
 
@@ -1631,6 +1703,8 @@ def integrate_stochastic(
         Final state dictionary after integration.
     """
 
+    if isinstance(steps, str) and steps not in ["adaptive", "dynamic"]:
+        raise ValueError(f"Unknown steps value: {steps!r}. Use an integer or 'adaptive'.")
     is_adaptive = isinstance(steps, str) and steps in ["adaptive", "dynamic"]
 
     if method == "glass":
@@ -1638,16 +1712,20 @@ def integrate_stochastic(
             raise ValueError("Adaptive step sizing is not supported for the 'glass' method.")
         if isinstance(steps, Sequence) or isinstance(steps, np.ndarray) or keras.ops.is_tensor(steps):
             raise ValueError("Scheduled integration is not supported for the 'glass' method.")
-        return integrate_glass(
-            fn=drift_fn,
-            state=state,
-            start_time=start_time,
-            stop_time=stop_time,
-            steps=steps,
-            noise_schedule=noise_schedule or "flow_matching",
-            seed=seed,
-            **kwargs,
-        )
+
+        def run_glass():
+            return integrate_glass(
+                fn=drift_fn,
+                state=state,
+                start_time=start_time,
+                stop_time=stop_time,
+                steps=steps,
+                noise_schedule=noise_schedule or "flow_matching",
+                seed=seed,
+                **kwargs,
+            )
+
+        return _compile_loop_integrator(run_glass)()
 
     if is_adaptive:
         if start_time is None or stop_time is None:
@@ -1706,19 +1784,26 @@ def integrate_stochastic(
                     shape = keras.ops.shape(val)
                     z_history[key] = keras.random.normal((loop_steps, *shape), dtype=keras.ops.dtype(val), seed=seed)
 
-            return integrate_langevin(
-                state=state,
-                start_time=start_time,
-                stop_time=stop_time,
-                steps=loop_steps,
-                z_history=z_history,
-                score_fn=score_fn,
-                noise_schedule=noise_schedule,
-                step_size_factor=step_size_factor,
-                corrector_steps=corrector_steps,
-                corrector_noise_history=corrector_noise_history,
-                seed=seed,
-            )
+            def run_langevin():
+                return integrate_langevin(
+                    state=state,
+                    start_time=start_time,
+                    stop_time=stop_time,
+                    steps=loop_steps,
+                    z_history=z_history,
+                    score_fn=score_fn,
+                    noise_schedule=noise_schedule,
+                    step_size_factor=step_size_factor,
+                    corrector_steps=corrector_steps,
+                    corrector_noise_history=corrector_noise_history,
+                    seed=seed,
+                )
+
+            result = _compile_loop_integrator(run_langevin)()
+            # covers the TensorFlow backend, where the check inside integrate_langevin is skipped while tracing
+            if _as_concrete_bool(_check_all_nans(result)):
+                raise RuntimeError("All values are NaNs in state during integration.")
+            return result
         case other:
             raise TypeError(f"Invalid integration method: {other!r}")
 
@@ -1737,40 +1822,47 @@ def integrate_stochastic(
             if method in ["sea", "shark"]:
                 z_extra_history[key] = keras.random.normal((loop_steps, *shape), dtype=keras.ops.dtype(val), seed=seed)
 
-    if is_adaptive:
-        return integrate_stochastic_adaptive(
-            step_fn=step_fn,
-            state=state,
-            start_time=start_time,
-            stop_time=stop_time,
-            max_steps=max_steps,
-            min_step_size=min_step_size,
-            max_step_size=max_step_size,
-            initial_step=initial_step,
-            z_history=z_history,
-            z_extra_history=z_extra_history,
-            corrector_steps=corrector_steps,
-            score_fn=score_fn,
-            noise_schedule=noise_schedule,
-            step_size_factor=step_size_factor,
-            corrector_noise_history=corrector_noise_history,
-            seed=seed,
-        )
-    else:
-        return integrate_stochastic_fixed(
-            step_fn=step_fn,
-            state=state,
-            start_time=start_time,
-            stop_time=stop_time,
-            min_step_size=min_step_size,
-            max_step_size=max_step_size,
-            steps=loop_steps,
-            z_history=z_history,
-            z_extra_history=z_extra_history,
-            corrector_steps=corrector_steps,
-            score_fn=score_fn,
-            noise_schedule=noise_schedule,
-            step_size_factor=step_size_factor,
-            corrector_noise_history=corrector_noise_history,
-            seed=seed,
-        )
+    def run():
+        if is_adaptive:
+            return integrate_stochastic_adaptive(
+                step_fn=step_fn,
+                state=state,
+                start_time=start_time,
+                stop_time=stop_time,
+                max_steps=max_steps,
+                min_step_size=min_step_size,
+                max_step_size=max_step_size,
+                initial_step=initial_step,
+                z_history=z_history,
+                z_extra_history=z_extra_history,
+                corrector_steps=corrector_steps,
+                score_fn=score_fn,
+                noise_schedule=noise_schedule,
+                step_size_factor=step_size_factor,
+                corrector_noise_history=corrector_noise_history,
+                seed=seed,
+            )
+        else:
+            return integrate_stochastic_fixed(
+                step_fn=step_fn,
+                state=state,
+                start_time=start_time,
+                stop_time=stop_time,
+                min_step_size=min_step_size,
+                max_step_size=max_step_size,
+                steps=loop_steps,
+                z_history=z_history,
+                z_extra_history=z_extra_history,
+                corrector_steps=corrector_steps,
+                score_fn=score_fn,
+                noise_schedule=noise_schedule,
+                step_size_factor=step_size_factor,
+                corrector_noise_history=corrector_noise_history,
+                seed=seed,
+            )
+
+    result = _compile_loop_integrator(run)()
+    # covers the TensorFlow backend, where the checks inside the integrators are skipped while tracing
+    if _as_concrete_bool(_check_all_nans(result)):
+        raise RuntimeError("All values are NaNs in state during integration.")
+    return result

--- a/bayesflow/utils/jacobian/jacobian.py
+++ b/bayesflow/utils/jacobian/jacobian.py
@@ -41,27 +41,18 @@ def jacobian(f: Callable[[Tensor], Tensor], x: Tensor, return_output: bool = Fal
     )
     fx, vjp_fn = vjp(f, x, return_output=True)
 
-    batch_shape = keras.ops.shape(x)[:-1]
-    batch_size = np.prod(batch_shape)
-
-    rows = keras.ops.shape(fx)[-1]
     cols = keras.ops.shape(x)[-1]
 
-    jac = keras.ops.zeros((*batch_shape, rows, cols))
-
+    jac_columns = []
     for col in range(cols):
         projector = np.zeros(keras.ops.shape(x), dtype=keras.ops.dtype(x))
         projector[..., col] = 1.0
         projector = keras.ops.convert_to_tensor(projector)
 
         # jac[..., col] = vjp_fn(projector)
-        indices = np.stack(list(np.ndindex(batch_shape + (rows,))))
-        indices = np.concatenate([indices, np.full((batch_size * rows, 1), col)], axis=1)
-        indices = keras.ops.convert_to_tensor(indices)
+        jac_columns.append(vjp_fn(projector))
 
-        updates = vjp_fn(projector)
-        updates = keras.ops.reshape(updates, (-1,))
-        jac = keras.ops.scatter_update(jac, indices, updates)
+    jac = keras.ops.stack(jac_columns, axis=-1)
 
     if return_output:
         return fx, jac

--- a/docsrc/poly.py
+++ b/docsrc/poly.py
@@ -113,7 +113,6 @@ src = Path(SOURCE_DIR)
 vcs = Git(
     branch_regex=BRANCH_REGEX,
     tag_regex=TAG_REGEX,
-    buffer_size=1 * 10**9,  # 1 GB
     predicate=file_predicate([src]),  # exclude refs without source dir
 )
 

--- a/tests/test_networks/conftest.py
+++ b/tests/test_networks/conftest.py
@@ -1,43 +1,55 @@
+import keras
 import pytest
 
 from bayesflow.networks import MLP
 
 
-def _make_diffusion_model(noise_schedule, prediction_type, subnet):
-    """Factory for DiffusionModel instances, avoiding 6 near-identical fixtures."""
+# ---------------------------------------------------------------------------
+# Shapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=[2, 3], scope="session")
+def xz_dim(request):
+    return request.param
+
+
+@pytest.fixture(params=[None, 3], scope="session")
+def cond_dim(request):
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def random_samples(batch_size, xz_dim):
+    return keras.random.normal((batch_size, xz_dim))
+
+
+@pytest.fixture(scope="session")
+def random_conditions(batch_size, cond_dim):
+    if cond_dim is None:
+        return None
+    return keras.random.normal((batch_size, cond_dim))
+
+
+# ---------------------------------------------------------------------------
+# One representative fixture per network family. Configuration variants
+# (noise schedules, prediction types, loss functions, ...) live in the
+# per-model test directories.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def diffusion_model():
     from bayesflow.networks import DiffusionModel
 
-    return DiffusionModel(
-        subnet=subnet,
-        subnet_kwargs=dict(widths=[8, 8]),
-        noise_schedule=noise_schedule,
-        prediction_type=prediction_type,
-    )
-
-
-@pytest.fixture()
-def diffusion_model_edm_F():
-    return _make_diffusion_model("edm", "F", "time_mlp")
-
-
-@pytest.fixture()
-def diffusion_model_cosine_velocity():
-    return _make_diffusion_model("cosine", "velocity", "time_mlp")
-
-
-@pytest.fixture()
-def diffusion_model_cosine_noise():
-    return _make_diffusion_model("cosine", "noise", "time_mlp")
-
-
-@pytest.fixture()
-def diffusion_model_edm_potential():
-    return _make_diffusion_model("edm", "potential", "time_mlp")
+    return DiffusionModel(subnet_kwargs=dict(widths=[8, 8]))
 
 
 @pytest.fixture()
 def diffusion_model_transformer():
-    return _make_diffusion_model("edm", "F", "diffusion_transformer")
+    from bayesflow.networks import DiffusionModel
+
+    return DiffusionModel(subnet="diffusion_transformer", subnet_kwargs=dict(widths=[8, 8]))
 
 
 @pytest.fixture()
@@ -175,16 +187,14 @@ def latent_coupling_flow():
         "affine_coupling_flow",
         "spline_coupling_flow",
         "flow_matching",
+        "flow_matching_transformer",
         "free_form_flow",
         "consistency_model",
         "stable_consistency_model",
         "latent_diffusion_model",
         "latent_coupling_flow",
-        pytest.param("diffusion_model_edm_F"),
-        pytest.param("diffusion_model_transformer"),
-        pytest.param("diffusion_model_cosine_velocity", marks=pytest.mark.slow),
-        pytest.param("diffusion_model_cosine_noise", marks=pytest.mark.slow),
-        pytest.param("diffusion_model_edm_potential", marks=pytest.mark.slow),
+        "diffusion_model",
+        "diffusion_model_transformer",
     ],
     scope="function",
 )
@@ -197,78 +207,17 @@ def inference_network(request):
         "affine_coupling_flow",
         "spline_coupling_flow",
         "flow_matching",
+        "flow_matching_transformer",
         "free_form_flow",
         "consistency_model",
         "stable_consistency_model",
-        pytest.param("diffusion_model_edm_F"),
-        pytest.param("diffusion_model_transformer"),
-        pytest.param("flow_matching_transformer"),
-        pytest.param("diffusion_model_cosine_velocity", marks=pytest.mark.slow),
-        pytest.param("diffusion_model_edm_potential", marks=pytest.mark.slow),
+        "diffusion_model",
+        "diffusion_model_transformer",
     ],
     scope="function",
 )
 def generative_inference_network(request):
     return request.getfixturevalue(request.param)
-
-
-@pytest.fixture(
-    params=[
-        "flow_matching",
-        "consistency_model",
-        "stable_consistency_model",
-        "diffusion_model",
-        "flow_matching_transformer",
-        "consistency_model_transformer",
-        "stable_consistency_model_transformer",
-        "diffusion_model_transformer",
-    ],
-    scope="function",
-)
-def diffusion_type_inference_network(request):
-    if request.param == "flow_matching":
-        from bayesflow.networks import FlowMatching
-
-        network = FlowMatching
-    elif request.param == "consistency_model":
-        from bayesflow.networks import ConsistencyModel
-
-        network = ConsistencyModel
-    elif request.param == "stable_consistency_model":
-        from bayesflow.networks import StableConsistencyModel
-
-        network = StableConsistencyModel
-    elif request.param == "diffusion_model":
-        from bayesflow.networks import DiffusionModel
-
-        network = DiffusionModel
-    elif request.param == "flow_matching_transformer":
-        import functools
-
-        from bayesflow.networks import FlowMatching
-
-        network = functools.partial(FlowMatching, subnet="diffusion_transformer")
-    elif request.param == "consistency_model_transformer":
-        import functools
-
-        from bayesflow.networks import ConsistencyModel
-
-        network = functools.partial(ConsistencyModel, subnet="diffusion_transformer")
-    elif request.param == "stable_consistency_model_transformer":
-        import functools
-
-        from bayesflow.networks import StableConsistencyModel
-
-        network = functools.partial(StableConsistencyModel, subnet="diffusion_transformer")
-    elif request.param == "diffusion_model_transformer":
-        import functools
-
-        from bayesflow.networks import DiffusionModel
-
-        network = functools.partial(DiffusionModel, subnet="diffusion_transformer")
-    else:
-        raise ValueError(f"Unknown request param: {request.param}")
-    return network
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_networks/test_consistency_model/conftest.py
+++ b/tests/test_networks/test_consistency_model/conftest.py
@@ -12,7 +12,7 @@ def batch_size(request):
     return request.param
 
 
-@pytest.fixture(params=[2, 5], scope="session")
+@pytest.fixture(params=[2], scope="session")
 def xz_dim(request):
     return request.param
 

--- a/tests/test_networks/test_consistency_model/test_consistency_model.py
+++ b/tests/test_networks/test_consistency_model/test_consistency_model.py
@@ -3,28 +3,11 @@ import numpy as np
 import pytest
 
 from bayesflow.utils.serialization import serialize, deserialize
-from tests.utils import assert_layers_equal
 
 
 # ===========================================================================
 # ConsistencyModel
 # ===========================================================================
-
-
-# ---- Build -----------------------------------------------------------------
-
-
-def test_build(consistency_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-
-    assert not consistency_model.built
-    consistency_model.build(xz_shape, conditions_shape=cond_shape)
-    assert consistency_model.built
-    assert consistency_model.variables
-
-
-# ---- Forward raises --------------------------------------------------------
 
 
 def test_forward_raises(consistency_model, random_samples, random_conditions):
@@ -36,9 +19,6 @@ def test_forward_raises(consistency_model, random_samples, random_conditions):
         consistency_model(random_samples, conditions=random_conditions)
 
 
-# ---- Output shapes ---------------------------------------------------------
-
-
 def test_inverse_output_shape(consistency_model, random_samples, random_conditions):
     xz_shape = keras.ops.shape(random_samples)
     cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
@@ -47,26 +27,7 @@ def test_inverse_output_shape(consistency_model, random_samples, random_conditio
     z = keras.random.normal(keras.ops.shape(random_samples))
     x = consistency_model(z, conditions=random_conditions, inverse=True)
     assert keras.ops.shape(x) == keras.ops.shape(random_samples)
-
-
-# ---- Variable batch size ---------------------------------------------------
-
-
-def test_variable_batch_size(consistency_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    consistency_model.build(xz_shape, conditions_shape=cond_shape)
-
-    for bs in [1, 4, 7]:
-        z = keras.random.normal((bs,) + keras.ops.shape(random_samples)[1:])
-        cond = (
-            None if random_conditions is None else keras.random.normal((bs,) + keras.ops.shape(random_conditions)[1:])
-        )
-        out = consistency_model(z, conditions=cond, inverse=True)
-        assert keras.ops.shape(out)[0] == bs
-
-
-# ---- Serialization ---------------------------------------------------------
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(x)))
 
 
 def test_serialize_deserialize(consistency_model, random_samples, random_conditions):
@@ -79,21 +40,6 @@ def test_serialize_deserialize(consistency_model, random_samples, random_conditi
     reserialized = serialize(deserialized)
 
     assert keras.tree.lists_to_tuples(serialized) == keras.tree.lists_to_tuples(reserialized)
-
-
-def test_save_and_load(tmp_path, consistency_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    consistency_model.build(xz_shape, conditions_shape=cond_shape)
-
-    path = tmp_path / "consistency.keras"
-    keras.saving.save_model(consistency_model, path)
-    loaded = keras.saving.load_model(path)
-
-    assert_layers_equal(consistency_model, loaded)
-
-
-# ---- compute_metrics -------------------------------------------------------
 
 
 def test_compute_metrics(consistency_model, random_samples, random_conditions):
@@ -123,22 +69,6 @@ def test_compute_metrics_with_masking(consistency_model_with_masking, random_sam
 # ===========================================================================
 
 
-# ---- Build -----------------------------------------------------------------
-
-
-def test_stable_build(stable_consistency_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-
-    assert not stable_consistency_model.built
-    stable_consistency_model.build(xz_shape, conditions_shape=cond_shape)
-    assert stable_consistency_model.built
-    assert stable_consistency_model.variables
-
-
-# ---- Forward raises --------------------------------------------------------
-
-
 def test_stable_forward_raises(stable_consistency_model, random_samples, random_conditions):
     xz_shape = keras.ops.shape(random_samples)
     cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
@@ -146,9 +76,6 @@ def test_stable_forward_raises(stable_consistency_model, random_samples, random_
 
     with pytest.raises(NotImplementedError):
         stable_consistency_model(random_samples, conditions=random_conditions)
-
-
-# ---- Output shapes ---------------------------------------------------------
 
 
 def test_stable_inverse_output_shape(stable_consistency_model, random_samples, random_conditions):
@@ -159,26 +86,7 @@ def test_stable_inverse_output_shape(stable_consistency_model, random_samples, r
     z = keras.random.normal(keras.ops.shape(random_samples))
     x = stable_consistency_model(z, conditions=random_conditions, inverse=True)
     assert keras.ops.shape(x) == keras.ops.shape(random_samples)
-
-
-# ---- Variable batch size ---------------------------------------------------
-
-
-def test_stable_variable_batch_size(stable_consistency_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    stable_consistency_model.build(xz_shape, conditions_shape=cond_shape)
-
-    for bs in [1, 4, 7]:
-        z = keras.random.normal((bs,) + keras.ops.shape(random_samples)[1:])
-        cond = (
-            None if random_conditions is None else keras.random.normal((bs,) + keras.ops.shape(random_conditions)[1:])
-        )
-        out = stable_consistency_model(z, conditions=cond, inverse=True)
-        assert keras.ops.shape(out)[0] == bs
-
-
-# ---- Serialization ---------------------------------------------------------
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(x)))
 
 
 def test_stable_serialize_deserialize(stable_consistency_model, random_samples, random_conditions):
@@ -191,21 +99,6 @@ def test_stable_serialize_deserialize(stable_consistency_model, random_samples, 
     reserialized = serialize(deserialized)
 
     assert keras.tree.lists_to_tuples(serialized) == keras.tree.lists_to_tuples(reserialized)
-
-
-def test_stable_save_and_load(tmp_path, stable_consistency_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    stable_consistency_model.build(xz_shape, conditions_shape=cond_shape)
-
-    path = tmp_path / "stable_consistency.keras"
-    keras.saving.save_model(stable_consistency_model, path)
-    loaded = keras.saving.load_model(path)
-
-    assert_layers_equal(stable_consistency_model, loaded)
-
-
-# ---- compute_metrics -------------------------------------------------------
 
 
 def test_stable_compute_metrics(stable_consistency_model, random_samples, random_conditions):

--- a/tests/test_networks/test_diffusion_model/conftest.py
+++ b/tests/test_networks/test_diffusion_model/conftest.py
@@ -36,7 +36,7 @@ def batch_size(request):
     return request.param
 
 
-@pytest.fixture(params=[2, 5], scope="session")
+@pytest.fixture(params=[2], scope="session")
 def xz_dim(request):
     return request.param
 
@@ -66,8 +66,11 @@ def random_conditions(batch_size, cond_dim):
 @pytest.fixture(
     params=[
         dict(noise_schedule="edm", prediction_type="F"),
-        dict(noise_schedule="cosine", prediction_type="velocity"),
+        dict(noise_schedule="edm", prediction_type="x"),
         dict(noise_schedule="edm", prediction_type="potential"),
+        dict(noise_schedule="cosine", prediction_type="velocity"),
+        dict(noise_schedule="cosine", prediction_type="noise"),
+        dict(noise_schedule="cosine", prediction_type="score"),
     ],
     ids=lambda d: f"{d['noise_schedule']}_{d['prediction_type']}",
 )

--- a/tests/test_networks/test_diffusion_model/test_diffusion_model.py
+++ b/tests/test_networks/test_diffusion_model/test_diffusion_model.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 from bayesflow.utils.serialization import serialize, deserialize
-from tests.utils import assert_layers_equal
+from tests.utils import assert_allclose, assert_layers_equal
 
 
 # ---- Noise schedule tests --------------------------------------------------
@@ -32,86 +32,109 @@ def test_validate_noise_schedule(noise_schedule):
     noise_schedule.validate()
 
 
-# ---- Build -----------------------------------------------------------------
+# ---- Configuration ---------------------------------------------------------
 
 
-def test_build(diffusion_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-
-    assert not diffusion_model.built
-    diffusion_model.build(xz_shape, conditions_shape=cond_shape)
-    assert diffusion_model.built
-    assert diffusion_model.variables
-
-
-def test_build_with_custom_integrate_kwargs(random_samples, random_conditions):
+def test_build_with_custom_integrate_kwargs():
     from bayesflow.networks import DiffusionModel
 
     model = DiffusionModel(
         subnet_kwargs=dict(widths=(8, 8)),
         integrate_kwargs=dict(method="euler", steps=10),
     )
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    model.build(xz_shape, conditions_shape=cond_shape)
+    model.build((2, 3), conditions_shape=(2, 3))
     assert model.built
     assert model.integrate_kwargs["method"] == "euler"
     assert model.integrate_kwargs["steps"] == 10
 
 
-# ---- Output shapes ---------------------------------------------------------
+# ---- Prediction type / noise schedule variants ------------------------------
+# The generic interface contract (shapes, batch sizes, save/load, ...) is
+# covered by test_networks/test_inference_networks.py for the default model.
+# The tests below run the model-specific configuration variants through the
+# training and (fixed-step, low-accuracy) sampling/density code paths.
 
 
-def test_inverse_output_shape(diffusion_model, random_samples, random_conditions):
+def test_compute_metrics(diffusion_model, random_samples, random_conditions):
     xz_shape = keras.ops.shape(random_samples)
     cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
     diffusion_model.build(xz_shape, conditions_shape=cond_shape)
 
-    z = keras.random.normal(keras.ops.shape(random_samples))
-    out = diffusion_model(z, conditions=random_conditions, inverse=True)
-    assert keras.ops.shape(out) == keras.ops.shape(random_samples)
+    metrics = diffusion_model.compute_metrics(random_samples, conditions=random_conditions)
+    assert "loss" in metrics
+    loss = keras.ops.convert_to_numpy(metrics["loss"])
+    assert np.isfinite(loss), f"Loss is not finite: {loss}"
 
 
-def test_inverse_density_output_shape(diffusion_model, random_samples, random_conditions):
+@pytest.mark.parametrize("loss_type", ["noise", "velocity", "F"])
+def test_compute_metrics_loss_types(loss_type, random_samples, random_conditions):
+    from bayesflow.networks import DiffusionModel
+
+    model = DiffusionModel(subnet_kwargs=dict(widths=(8, 8)), loss_type=loss_type)
+    xz_shape = keras.ops.shape(random_samples)
+    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
+    model.build(xz_shape, conditions_shape=cond_shape)
+
+    metrics = model.compute_metrics(random_samples, conditions=random_conditions)
+    loss = keras.ops.convert_to_numpy(metrics["loss"])
+    assert np.isfinite(loss), f"Loss is not finite: {loss}"
+
+
+def test_sample_and_density(diffusion_model, random_samples, random_conditions):
+    """Each prediction type supports sampling and density evaluation in both directions.
+
+    Accuracy is checked in test_inference_networks.py::test_density_numerically;
+    here a few fixed solver steps suffice to exercise the velocity/score conversions.
+    """
     xz_shape = keras.ops.shape(random_samples)
     cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
     diffusion_model.build(xz_shape, conditions_shape=cond_shape)
+    diffusion_model.integrate_kwargs.update({"method": "rk45", "steps": 8})
 
-    z = keras.random.normal(keras.ops.shape(random_samples))
+    z = keras.random.normal(xz_shape)
     x, log_density = diffusion_model(z, conditions=random_conditions, inverse=True, density=True)
-    assert keras.ops.shape(x) == keras.ops.shape(random_samples)
-    assert keras.ops.shape(log_density) == (keras.ops.shape(random_samples)[0],)
-
-
-def test_forward_density_output_shape(diffusion_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    diffusion_model.build(xz_shape, conditions_shape=cond_shape)
+    assert keras.ops.shape(x) == xz_shape
+    assert keras.ops.shape(log_density) == (xz_shape[0],)
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(x)))
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(log_density)))
 
     z, log_density = diffusion_model(random_samples, conditions=random_conditions, density=True)
-    assert keras.ops.shape(z) == keras.ops.shape(random_samples)
-    assert keras.ops.shape(log_density) == (keras.ops.shape(random_samples)[0],)
+    assert keras.ops.shape(z) == xz_shape
+    assert keras.ops.shape(log_density) == (xz_shape[0],)
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(z)))
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(log_density)))
 
 
-# ---- Variable batch size ---------------------------------------------------
+def test_adaptive_solver_sample_and_density():
+    """The instance defaults are adaptive solvers (stochastic sampling, adaptive ODE for
+    density). The adaptive density must match a high-accuracy fixed-step reference, which
+    in turn is verified against a numerical jacobian in
+    test_inference_networks.py::test_density_numerically."""
+    from bayesflow.networks import DiffusionModel
 
+    model = DiffusionModel(subnet_kwargs=dict(widths=(8, 8)))
+    conditions = keras.random.normal((2, 3))
+    model.build((2, 3), conditions_shape=(2, 3))
 
-def test_variable_batch_size(diffusion_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    diffusion_model.build(xz_shape, conditions_shape=cond_shape)
+    # sampling with the default (stochastic, adaptive) solver
+    z = keras.random.normal((2, 3))
+    x = model(z, conditions=conditions, inverse=True)
+    assert keras.ops.shape(x) == (2, 3)
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(x)))
 
-    for bs in [1, 4, 7]:
-        z = keras.random.normal((bs,) + keras.ops.shape(random_samples)[1:])
-        cond = (
-            None if random_conditions is None else keras.random.normal((bs,) + keras.ops.shape(random_conditions)[1:])
-        )
-        out = diffusion_model(z, conditions=cond, inverse=True)
-        assert keras.ops.shape(out)[0] == bs
+    # density with the adaptive ODE solver, in both directions
+    x_adaptive, ld_inv_adaptive = model(z, conditions=conditions, inverse=True, density=True)
+    z_adaptive, ld_fwd_adaptive = model(x_adaptive, conditions=conditions, density=True)
 
+    # high-accuracy fixed-step reference
+    model.integrate_kwargs.update({"steps": 150})
+    x_fixed, ld_inv_fixed = model(z, conditions=conditions, inverse=True, density=True)
+    z_fixed, ld_fwd_fixed = model(x_adaptive, conditions=conditions, density=True)
 
-# ---- Serialization ---------------------------------------------------------
+    assert_allclose(x_adaptive, x_fixed, atol=1e-3, rtol=1e-3)
+    assert_allclose(ld_inv_adaptive, ld_inv_fixed, atol=1e-3, rtol=1e-3)
+    assert_allclose(z_adaptive, z_fixed, atol=1e-3, rtol=1e-3)
+    assert_allclose(ld_fwd_adaptive, ld_fwd_fixed, atol=1e-3, rtol=1e-3)
 
 
 def test_serialize_deserialize(diffusion_model, random_samples, random_conditions):
@@ -138,18 +161,7 @@ def test_save_and_load(tmp_path, diffusion_model, random_samples, random_conditi
     assert_layers_equal(diffusion_model, loaded)
 
 
-# ---- compute_metrics -------------------------------------------------------
-
-
-def test_compute_metrics(diffusion_model, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    diffusion_model.build(xz_shape, conditions_shape=cond_shape)
-
-    metrics = diffusion_model.compute_metrics(random_samples, conditions=random_conditions)
-    assert "loss" in metrics
-    loss = keras.ops.convert_to_numpy(metrics["loss"])
-    assert np.isfinite(loss), f"Loss is not finite: {loss}"
+# ---- Masking ----------------------------------------------------------------
 
 
 def test_compute_metrics_with_masking(diffusion_model_with_masking, random_samples, random_conditions):

--- a/tests/test_networks/test_flow_matching/conftest.py
+++ b/tests/test_networks/test_flow_matching/conftest.py
@@ -12,7 +12,7 @@ def batch_size(request):
     return request.param
 
 
-@pytest.fixture(params=[2, 5], scope="session")
+@pytest.fixture(params=[2], scope="session")
 def xz_dim(request):
     return request.param
 

--- a/tests/test_networks/test_flow_matching/test_flow_matching.py
+++ b/tests/test_networks/test_flow_matching/test_flow_matching.py
@@ -2,160 +2,26 @@ import keras
 import numpy as np
 
 from bayesflow.utils.serialization import serialize, deserialize
-from tests.utils import assert_layers_equal, assert_allclose
+from tests.utils import assert_allclose
 
 
-# ---- Build -----------------------------------------------------------------
+# ---- Configuration ---------------------------------------------------------
 
 
-def test_build(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-
-    assert not flow_matching.built
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-    assert flow_matching.built
-    assert flow_matching.variables
-
-
-def test_build_with_custom_integrate_kwargs(random_samples, random_conditions):
+def test_build_with_custom_integrate_kwargs():
     from bayesflow.networks import FlowMatching
 
     model = FlowMatching(
         subnet_kwargs=dict(widths=(8, 8)),
         integrate_kwargs=dict(method="euler", steps=10),
     )
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    model.build(xz_shape, conditions_shape=cond_shape)
+    model.build((2, 3), conditions_shape=(2, 3))
     assert model.built
     assert model.integrate_kwargs["method"] == "euler"
     assert model.integrate_kwargs["steps"] == 10
 
 
-# ---- Output shapes ---------------------------------------------------------
-
-
-def test_forward_output_shape(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    z = flow_matching(random_samples, conditions=random_conditions)
-    assert keras.ops.shape(z) == keras.ops.shape(random_samples)
-
-
-def test_forward_density_output_shape(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    z, log_density = flow_matching(random_samples, conditions=random_conditions, density=True)
-    assert keras.ops.shape(z) == keras.ops.shape(random_samples)
-    assert keras.ops.shape(log_density) == (keras.ops.shape(random_samples)[0],)
-
-
-def test_inverse_output_shape(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    z = keras.random.normal(keras.ops.shape(random_samples))
-    x = flow_matching(z, conditions=random_conditions, inverse=True)
-    assert keras.ops.shape(x) == keras.ops.shape(random_samples)
-
-
-def test_inverse_density_output_shape(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    z = keras.random.normal(keras.ops.shape(random_samples))
-    x, log_density = flow_matching(z, conditions=random_conditions, inverse=True, density=True)
-    assert keras.ops.shape(x) == keras.ops.shape(random_samples)
-    assert keras.ops.shape(log_density) == (keras.ops.shape(random_samples)[0],)
-
-
-# ---- Variable batch size ---------------------------------------------------
-
-
-def test_variable_batch_size(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    for bs in [1, 4, 7]:
-        z = keras.random.normal((bs,) + keras.ops.shape(random_samples)[1:])
-        cond = (
-            None if random_conditions is None else keras.random.normal((bs,) + keras.ops.shape(random_conditions)[1:])
-        )
-        out = flow_matching(z, conditions=cond, inverse=True)
-        assert keras.ops.shape(out)[0] == bs
-
-
-# ---- Cycle consistency (forward ∘ inverse ≈ identity) ----------------------
-
-
-def test_cycle_consistency(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    z, fwd_log_density = flow_matching(random_samples, conditions=random_conditions, density=True)
-    x_reconstructed, inv_log_density = flow_matching(z, conditions=random_conditions, inverse=True, density=True)
-
-    assert_allclose(random_samples, x_reconstructed, atol=1e-3, rtol=1e-3)
-    assert_allclose(fwd_log_density, inv_log_density, atol=1e-3, rtol=1e-3)
-
-
-# ---- Serialization ---------------------------------------------------------
-
-
-def test_serialize_deserialize(flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    serialized = serialize(flow_matching)
-    deserialized = deserialize(serialized)
-    reserialized = serialize(deserialized)
-
-    assert keras.tree.lists_to_tuples(serialized) == keras.tree.lists_to_tuples(reserialized)
-
-
-def test_save_and_load(tmp_path, flow_matching, random_samples, random_conditions):
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    flow_matching.build(xz_shape, conditions_shape=cond_shape)
-
-    path = tmp_path / "flow_matching.keras"
-    keras.saving.save_model(flow_matching, path)
-    loaded = keras.saving.load_model(path)
-
-    assert_layers_equal(flow_matching, loaded)
-
-
-def test_save_load_output_unchanged(tmp_path, random_samples, random_conditions):
-    """Loaded model produces the same output as the original."""
-    from bayesflow.networks import FlowMatching
-
-    model = FlowMatching(subnet_kwargs=dict(widths=(8, 8)))
-    xz_shape = keras.ops.shape(random_samples)
-    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
-    model.build(xz_shape, conditions_shape=cond_shape)
-
-    z = keras.random.normal(keras.ops.shape(random_samples))
-    original_out = model(z, conditions=random_conditions, inverse=True)
-
-    path = tmp_path / "fm_output_check.keras"
-    keras.saving.save_model(model, path)
-    loaded = keras.saving.load_model(path)
-
-    loaded_out = loaded(z, conditions=random_conditions, inverse=True)
-    assert_allclose(original_out, loaded_out, atol=1e-5, rtol=1e-5)
-
-
-# ---- compute_metrics -------------------------------------------------------
+# ---- compute_metrics (training path of each variant) ------------------------
 
 
 def test_compute_metrics(flow_matching, random_samples, random_conditions):
@@ -178,3 +44,71 @@ def test_compute_metrics_with_masking(flow_matching_with_masking, random_samples
     assert "loss" in metrics
     loss = keras.ops.convert_to_numpy(metrics["loss"])
     assert np.isfinite(loss), f"Loss is not finite: {loss}"
+
+
+def test_adaptive_solver_sample_and_density():
+    """The instance default is an adaptive tsit5 solver for sampling and density.
+    The adaptive density must match a high-accuracy fixed-step reference, which
+    in turn is verified against a numerical jacobian in
+    test_inference_networks.py::test_density_numerically."""
+    from bayesflow.networks import FlowMatching
+
+    model = FlowMatching(subnet_kwargs=dict(widths=(8, 8)))
+    conditions = keras.random.normal((2, 3))
+    model.build((2, 3), conditions_shape=(2, 3))
+
+    # sampling with the default adaptive solver
+    z = keras.random.normal((2, 3))
+    x = model(z, conditions=conditions, inverse=True)
+    assert keras.ops.shape(x) == (2, 3)
+    assert np.all(np.isfinite(keras.ops.convert_to_numpy(x)))
+
+    # density with the adaptive solver, in both directions
+    x_adaptive, ld_inv_adaptive = model(z, conditions=conditions, inverse=True, density=True)
+    z_adaptive, ld_fwd_adaptive = model(x_adaptive, conditions=conditions, density=True)
+
+    # high-accuracy fixed-step reference
+    model.integrate_kwargs.update({"steps": 150})
+    x_fixed, ld_inv_fixed = model(z, conditions=conditions, inverse=True, density=True)
+    z_fixed, ld_fwd_fixed = model(x_adaptive, conditions=conditions, density=True)
+
+    assert_allclose(x_adaptive, x_fixed, atol=1e-3, rtol=1e-3)
+    assert_allclose(ld_inv_adaptive, ld_inv_fixed, atol=1e-3, rtol=1e-3)
+    assert_allclose(z_adaptive, z_fixed, atol=1e-3, rtol=1e-3)
+    assert_allclose(ld_fwd_adaptive, ld_fwd_fixed, atol=1e-3, rtol=1e-3)
+
+
+# ---- Serialization ---------------------------------------------------------
+
+
+def test_serialize_deserialize(flow_matching, random_samples, random_conditions):
+    xz_shape = keras.ops.shape(random_samples)
+    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
+    flow_matching.build(xz_shape, conditions_shape=cond_shape)
+
+    serialized = serialize(flow_matching)
+    deserialized = deserialize(serialized)
+    reserialized = serialize(deserialized)
+
+    assert keras.tree.lists_to_tuples(serialized) == keras.tree.lists_to_tuples(reserialized)
+
+
+def test_save_load_output_unchanged(tmp_path, random_samples, random_conditions):
+    """Loaded model produces the same output as the original."""
+    from bayesflow.networks import FlowMatching
+
+    # a few fixed euler steps keep sampling cheap and deterministic
+    model = FlowMatching(subnet_kwargs=dict(widths=(8, 8)), integrate_kwargs=dict(method="euler", steps=8))
+    xz_shape = keras.ops.shape(random_samples)
+    cond_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
+    model.build(xz_shape, conditions_shape=cond_shape)
+
+    z = keras.random.normal(keras.ops.shape(random_samples))
+    original_out = model(z, conditions=random_conditions, inverse=True)
+
+    path = tmp_path / "fm_output_check.keras"
+    keras.saving.save_model(model, path)
+    loaded = keras.saving.load_model(path)
+
+    loaded_out = loaded(z, conditions=random_conditions, inverse=True)
+    assert_allclose(original_out, loaded_out, atol=1e-5, rtol=1e-5)

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -3,21 +3,15 @@ import numpy as np
 import pytest
 
 from bayesflow.utils.serialization import serialize, deserialize
-from bayesflow.utils import filter_kwargs
 
 from tests.utils import assert_allclose, assert_layers_equal
 
 
-def _skip_torch_cpu_masking_workflow():
-    if keras.backend.backend() != "torch":
-        return
-
-    import torch
-
-    if torch.cuda.device_count() == 0:
-        pytest.skip(
-            "PyTorch CPU scaled-dot-product attention does not support forward-mode AD used by the masking workflow."
-        )
+def _use_fast_integration(network, steps=8):
+    """Use a few fixed integration steps for tests whose assertions do not
+    depend on solver accuracy (shapes, structure, batch sizes)."""
+    if hasattr(network, "integrate_kwargs"):
+        network.integrate_kwargs.update({"steps": steps})
 
 
 def test_build(inference_network, random_samples, random_conditions):
@@ -44,6 +38,7 @@ def test_variable_batch_size(inference_network, random_samples, random_condition
     samples_shape = keras.ops.shape(random_samples)
     conditions_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
     inference_network.build(samples_shape, conditions_shape=conditions_shape)
+    _use_fast_integration(inference_network)
 
     # run with another batch size
     batch_sizes = np.random.choice(10, replace=False, size=3)
@@ -69,6 +64,7 @@ def test_variable_batch_size(inference_network, random_samples, random_condition
 
 @pytest.mark.parametrize("density", [True, False])
 def test_output_structure(density, generative_inference_network, random_samples, random_conditions):
+    _use_fast_integration(generative_inference_network)
     try:
         output = generative_inference_network(random_samples, conditions=random_conditions, density=density)
     except NotImplementedError:
@@ -88,6 +84,7 @@ def test_output_structure(density, generative_inference_network, random_samples,
 
 
 def test_output_shape(generative_inference_network, random_samples, random_conditions):
+    _use_fast_integration(generative_inference_network)
     try:
         forward_output, forward_log_density = generative_inference_network(
             random_samples, conditions=random_conditions, density=True
@@ -113,6 +110,9 @@ def test_cycle_consistency(generative_inference_network, random_samples, random_
 
     if isinstance(generative_inference_network, bf.networks.DiffusionModel):
         pytest.skip(reason="test unstable for untrained diffusion models")
+    # 50 fixed steps leave a discretization error orders of magnitude below the
+    # tolerances while being much cheaper than an adaptive solve
+    _use_fast_integration(generative_inference_network, steps=50)
     try:
         forward_output, forward_log_density = generative_inference_network(
             random_samples, conditions=random_conditions, density=True
@@ -127,28 +127,31 @@ def test_cycle_consistency(generative_inference_network, random_samples, random_
     assert_allclose(forward_log_density, inverse_log_density, atol=1e-3, rtol=1e-3)
 
 
-def test_density_numerically(generative_inference_network, random_samples, random_conditions):
+@pytest.mark.parametrize(
+    "network_name",
+    # one representative per density implementation
+    ["affine_coupling_flow", "spline_coupling_flow", "free_form_flow", "flow_matching", "diffusion_model"],
+)
+def test_density_numerically(network_name, request):
+    # The reference computation (numerical jacobian of the full integration) is expensive,
+    # so this test runs on a single small input instead of the full shape grid
     from bayesflow.utils import jacobian
 
-    try:
-        if keras.backend.backend() == "jax" and hasattr(generative_inference_network, "integrate_kwargs"):
-            # jax backend does not support adaptive solvers for numerical jacobian computation yet
-            if generative_inference_network.integrate_kwargs["steps"] == "adaptive":
-                generative_inference_network.integrate_kwargs.update({"steps": 250})
+    network = request.getfixturevalue(network_name)
 
-        output, log_density = generative_inference_network(random_samples, conditions=random_conditions, density=True)
-    except NotImplementedError:
-        # network does not support density estimation
-        return
+    random_samples = keras.random.normal((2, 3))
+    random_conditions = keras.random.normal((2, 3))
 
-    log_prob = generative_inference_network.base_distribution.log_prob(output)
+    # Use the same fixed-step solver for the network density and the numerical reference,
+    if hasattr(network, "integrate_kwargs"):
+        network.integrate_kwargs.update({"steps": 50})
 
-    # for the numerical output do not use an adaptive solver as this tends to be unreliable
-    if hasattr(generative_inference_network, "integrate_kwargs"):
-        generative_inference_network.integrate_kwargs.update({"steps": 250})
+    output, log_density = network(random_samples, conditions=random_conditions, density=True)
+
+    log_prob = network.base_distribution.log_prob(output)
 
     def f(x):
-        return generative_inference_network(x, conditions=random_conditions)
+        return network(x, conditions=random_conditions)
 
     numerical_output, numerical_jacobian = jacobian(f, random_samples, return_output=True)
 
@@ -199,118 +202,7 @@ def test_compute_metrics(inference_network, random_samples, random_conditions):
     xz_shape = keras.ops.shape(random_samples)
     conditions_shape = keras.ops.shape(random_conditions) if random_conditions is not None else None
 
-    print(f"{inference_network.__class__.__name__=}")
-    print(f"{xz_shape=}, {conditions_shape=}")
     inference_network.build(xz_shape, conditions_shape)
 
     metrics = inference_network.compute_metrics(random_samples, conditions=random_conditions)
     assert "loss" in metrics
-
-
-def test_masking(diffusion_type_inference_network):
-    _skip_torch_cpu_masking_workflow()
-
-    from bayesflow import BasicWorkflow
-    from bayesflow.simulators import TwoMoons
-
-    num_samples = 3
-    batch_size = 2
-    num_batches_per_epoch = 2
-    epochs = 5
-    n_test_data = 5
-    workflow = BasicWorkflow(
-        inference_network=diffusion_type_inference_network(
-            subnet_kwargs=dict(widths=(8, 8)),
-            fixed_target_prob=0.5,
-            missing_target_prob=0.5,
-            **filter_kwargs(
-                dict(total_steps=epochs * num_batches_per_epoch, s0=3, s1=10, eps=1e-8),
-                diffusion_type_inference_network,
-            ),
-        ),
-        inference_variables=["parameters"],
-        inference_conditions=["observables"],
-        simulator=TwoMoons(),
-    )
-
-    workflow.fit_online(epochs=epochs, batch_size=batch_size, num_batches_per_epoch=num_batches_per_epoch)
-    test_conditions = workflow.simulate((n_test_data,))
-    samples = workflow.sample(num_samples=num_samples, conditions=test_conditions)["parameters"]
-
-    test_conditions_adapted = workflow.adapter(test_conditions)
-    fixed_target_mask = keras.ops.concatenate(
-        (
-            keras.ops.ones(1),  # param 1 is inferred
-            keras.ops.zeros(1),  # param 2 is fixed
-        )
-    )
-    fixed_target_mask = np.broadcast_to(fixed_target_mask, (n_test_data, 2))
-    targets_fixed = test_conditions_adapted["inference_variables"]
-
-    fixed_samples = workflow.sample(
-        conditions=test_conditions,
-        num_samples=num_samples,
-        fixed_target_value=targets_fixed,
-        fixed_target_mask=fixed_target_mask,
-    )["parameters"]
-    assert samples.shape == fixed_samples.shape
-    assert (np.abs(fixed_samples[..., 1] - test_conditions["parameters"][:, 1:]) < 1e-6).all()
-    assert (np.abs(fixed_samples[..., 0] - test_conditions["parameters"][:, :1]) > 0.1).any()  # should vary
-
-    infer_target_mask = keras.ops.concatenate(
-        (
-            keras.ops.ones(1),  # param 1 is inferred only
-            keras.ops.zeros(1),  # param 2 is marginalized
-        )
-    )
-    infer_target_mask = np.broadcast_to(infer_target_mask, (5, 2))
-    marginalized_samples = workflow.sample(
-        conditions=test_conditions,
-        num_samples=num_samples,
-        infer_target_mask=infer_target_mask,
-    )["parameters"]
-    assert samples.shape == marginalized_samples.shape
-
-
-def test_masking_unconditional(diffusion_type_inference_network):
-    _skip_torch_cpu_masking_workflow()
-
-    from bayesflow import BasicWorkflow
-    from bayesflow.simulators import TwoMoons
-
-    num_samples = 3
-    batch_size = 2
-    num_batches_per_epoch = 2
-    epochs = 5
-    workflow = BasicWorkflow(
-        inference_network=diffusion_type_inference_network(
-            subnet_kwargs=dict(widths=(8, 8)),
-            fixed_target_prob=0.5,
-            **filter_kwargs(
-                dict(total_steps=epochs * num_batches_per_epoch, s0=3, s1=10, eps=1e-8),
-                diffusion_type_inference_network,
-            ),
-        ),
-        inference_variables=["parameters"],
-        simulator=TwoMoons(),
-    )
-
-    workflow.fit_online(epochs=epochs, batch_size=batch_size, num_batches_per_epoch=num_batches_per_epoch)
-    test_conditions = workflow.simulate((5,))
-
-    test_conditions_adapted = workflow.adapter(test_conditions)
-    fixed_target_mask = keras.ops.concatenate(
-        (
-            keras.ops.ones(1),  # param 1 is inferred
-            keras.ops.zeros(1),  # param 2 is fixed
-        )
-    )
-    fixed_target_mask = np.broadcast_to(fixed_target_mask, (5, num_samples, 2)).reshape(-1, 2)
-    targets_fixed = test_conditions_adapted["inference_variables"]
-    targets_fixed = np.broadcast_to(np.expand_dims(targets_fixed, axis=1), (5, num_samples, 2)).reshape(-1, 2)
-
-    fixed_samples = workflow.sample(
-        num_samples=num_samples * 5, fixed_target_value=targets_fixed, fixed_target_mask=fixed_target_mask
-    )["parameters"].reshape(5, num_samples, 2)
-    assert (np.abs(fixed_samples[..., 1] - test_conditions["parameters"][:, 1:]) < 1e-6).all()
-    assert (np.abs(fixed_samples[..., 0] - test_conditions["parameters"][:, :1]) > 0.1).any()  # should vary

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -153,7 +153,9 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     numerical_output, numerical_jacobian = jacobian(f, random_samples, return_output=True)
 
     # output should be identical, otherwise this test does not work (e.g. for stochastic networks)
-    assert_allclose(output, numerical_output, msg="Outputs of numerical jacobian and network do not match.")
+    assert_allclose(
+        output, numerical_output, rtol=1e-5, atol=1e-5, msg="Outputs of numerical jacobian and network do not match."
+    )
 
     # use change of variables to compute the numerical log density
     numerical_log_density = log_prob + keras.ops.log(keras.ops.abs(keras.ops.det(numerical_jacobian)))

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -145,7 +145,7 @@ def test_density_numerically(generative_inference_network, random_samples, rando
 
     # for the numerical output do not use an adaptive solver as this tends to be unreliable
     if hasattr(generative_inference_network, "integrate_kwargs"):
-        generative_inference_network.integrate_kwargs.update({"steps": 200})
+        generative_inference_network.integrate_kwargs.update({"steps": 250})
 
     def f(x):
         return generative_inference_network(x, conditions=random_conditions)
@@ -162,8 +162,8 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     assert_allclose(
         log_density,
         numerical_log_density,
-        rtol=1e-3,
-        atol=1e-3,
+        rtol=1e-4,
+        atol=1e-4,
         msg="Density of numerical jacobian and network do not match.",
     )
 

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -162,8 +162,8 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     assert_allclose(
         log_density,
         numerical_log_density,
-        rtol=1e-4,
-        atol=1e-4,
+        rtol=1e-3,
+        atol=1e-3,
         msg="Density of numerical jacobian and network do not match.",
     )
 

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -144,7 +144,9 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     log_prob = generative_inference_network.base_distribution.log_prob(output)
 
     # for the numerical output increase tolerances of an adaptive sampler if any is used
-    generative_inference_network.integrate_kwargs.update({"atol": 1e-8, "rtol": 1e-8})
+    if hasattr(generative_inference_network, "integrate_kwargs"):
+        # needed to be comparable as this has only one state
+        generative_inference_network.integrate_kwargs.update({"atol": 1e-8, "rtol": 1e-8})
 
     def f(x):
         return generative_inference_network(x, conditions=random_conditions)

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -165,8 +165,8 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     assert_allclose(
         log_density,
         numerical_log_density,
-        rtol=1e-4,
-        atol=1e-4,
+        rtol=1e-3,
+        atol=1e-3,
         msg="Density of numerical jacobian and network do not match.",
     )
 

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -141,6 +141,11 @@ def test_density_numerically(generative_inference_network, random_samples, rando
         # network does not support density estimation
         return
 
+    log_prob = generative_inference_network.base_distribution.log_prob(output)
+
+    # for the numerical output increase tolerances of an adaptive sampler if any is used
+    generative_inference_network.integrate_kwargs.update({"atol": 1e-8, "rtol": 1e-8})
+
     def f(x):
         return generative_inference_network(x, conditions=random_conditions)
 
@@ -148,10 +153,8 @@ def test_density_numerically(generative_inference_network, random_samples, rando
 
     # output should be identical, otherwise this test does not work (e.g. for stochastic networks)
     assert_allclose(
-        output, numerical_output, rtol=1e-3, atol=1e-3, msg="Outputs of numerical jacobian and network do not match."
+        output, numerical_output, rtol=1e-4, atol=1e-4, msg="Outputs of numerical jacobian and network do not match."
     )
-
-    log_prob = generative_inference_network.base_distribution.log_prob(output)
 
     # use change of variables to compute the numerical log density
     numerical_log_density = log_prob + keras.ops.log(keras.ops.abs(keras.ops.det(numerical_jacobian)))
@@ -160,8 +163,8 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     assert_allclose(
         log_density,
         numerical_log_density,
-        rtol=1e-3,
-        atol=1e-3,
+        rtol=1e-4,
+        atol=1e-4,
         msg="Density of numerical jacobian and network do not match.",
     )
 

--- a/tests/test_networks/test_inference_networks.py
+++ b/tests/test_networks/test_inference_networks.py
@@ -143,10 +143,9 @@ def test_density_numerically(generative_inference_network, random_samples, rando
 
     log_prob = generative_inference_network.base_distribution.log_prob(output)
 
-    # for the numerical output increase tolerances of an adaptive sampler if any is used
+    # for the numerical output do not use an adaptive solver as this tends to be unreliable
     if hasattr(generative_inference_network, "integrate_kwargs"):
-        # needed to be comparable as this has only one state
-        generative_inference_network.integrate_kwargs.update({"atol": 1e-8, "rtol": 1e-8})
+        generative_inference_network.integrate_kwargs.update({"steps": 200})
 
     def f(x):
         return generative_inference_network(x, conditions=random_conditions)
@@ -154,9 +153,7 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     numerical_output, numerical_jacobian = jacobian(f, random_samples, return_output=True)
 
     # output should be identical, otherwise this test does not work (e.g. for stochastic networks)
-    assert_allclose(
-        output, numerical_output, rtol=1e-4, atol=1e-4, msg="Outputs of numerical jacobian and network do not match."
-    )
+    assert_allclose(output, numerical_output, msg="Outputs of numerical jacobian and network do not match.")
 
     # use change of variables to compute the numerical log density
     numerical_log_density = log_prob + keras.ops.log(keras.ops.abs(keras.ops.det(numerical_jacobian)))
@@ -165,8 +162,8 @@ def test_density_numerically(generative_inference_network, random_samples, rando
     assert_allclose(
         log_density,
         numerical_log_density,
-        rtol=1e-3,
-        atol=1e-3,
+        rtol=1e-4,
+        atol=1e-4,
         msg="Density of numerical jacobian and network do not match.",
     )
 

--- a/tests/test_networks/test_masking.py
+++ b/tests/test_networks/test_masking.py
@@ -1,0 +1,166 @@
+import functools
+
+import keras
+import numpy as np
+import pytest
+
+from bayesflow.utils import filter_kwargs
+
+
+def _network_class(name):
+    from bayesflow.networks import ConsistencyModel, DiffusionModel, FlowMatching, StableConsistencyModel
+
+    return {
+        "flow_matching": FlowMatching,
+        "consistency_model": ConsistencyModel,
+        "stable_consistency_model": StableConsistencyModel,
+        "diffusion_model": DiffusionModel,
+    }[name]
+
+
+@pytest.fixture(
+    params=[
+        "flow_matching",
+        "consistency_model",
+        "stable_consistency_model",
+        "diffusion_model",
+        "flow_matching_transformer",
+        "consistency_model_transformer",
+        "stable_consistency_model_transformer",
+        "diffusion_model_transformer",
+    ],
+    scope="function",
+)
+def diffusion_type_inference_network(request):
+    name, transformer_suffix, _ = request.param.partition("_transformer")
+    network = _network_class(name)
+    if transformer_suffix:
+        network = functools.partial(network, subnet="diffusion_transformer")
+    return network
+
+
+def _skip_torch_cpu_masking_workflow():
+    if keras.backend.backend() != "torch":
+        return
+
+    import torch
+
+    if torch.cuda.device_count() == 0:
+        pytest.skip(
+            "PyTorch CPU scaled-dot-product attention does not support forward-mode AD used by the masking workflow."
+        )
+
+
+def _build_network(diffusion_type_inference_network, epochs, num_batches_per_epoch, **extra_kwargs):
+    # sampling accuracy is irrelevant here, so ODE-based networks use a few fixed euler steps
+    return diffusion_type_inference_network(
+        subnet_kwargs=dict(widths=(8, 8)),
+        fixed_target_prob=0.5,
+        **extra_kwargs,
+        **filter_kwargs(
+            dict(
+                total_steps=epochs * num_batches_per_epoch,
+                s0=3,
+                s1=10,
+                eps=1e-8,
+                integrate_kwargs=dict(method="euler", steps=20),
+            ),
+            diffusion_type_inference_network,
+        ),
+    )
+
+
+def test_masking(diffusion_type_inference_network):
+    _skip_torch_cpu_masking_workflow()
+
+    from bayesflow import BasicWorkflow
+    from bayesflow.simulators import TwoMoons
+
+    num_samples = 3
+    batch_size = 2
+    num_batches_per_epoch = 2
+    epochs = 5
+    n_test_data = 5
+    workflow = BasicWorkflow(
+        inference_network=_build_network(
+            diffusion_type_inference_network, epochs, num_batches_per_epoch, missing_target_prob=0.5
+        ),
+        inference_variables=["parameters"],
+        inference_conditions=["observables"],
+        simulator=TwoMoons(),
+    )
+
+    workflow.fit_online(epochs=epochs, batch_size=batch_size, num_batches_per_epoch=num_batches_per_epoch)
+    test_conditions = workflow.simulate((n_test_data,))
+    samples = workflow.sample(num_samples=num_samples, conditions=test_conditions)["parameters"]
+
+    test_conditions_adapted = workflow.adapter(test_conditions)
+    fixed_target_mask = keras.ops.concatenate(
+        (
+            keras.ops.ones(1),  # param 1 is inferred
+            keras.ops.zeros(1),  # param 2 is fixed
+        )
+    )
+    fixed_target_mask = np.broadcast_to(fixed_target_mask, (n_test_data, 2))
+    targets_fixed = test_conditions_adapted["inference_variables"]
+
+    fixed_samples = workflow.sample(
+        conditions=test_conditions,
+        num_samples=num_samples,
+        fixed_target_value=targets_fixed,
+        fixed_target_mask=fixed_target_mask,
+    )["parameters"]
+    assert samples.shape == fixed_samples.shape
+    assert (np.abs(fixed_samples[..., 1] - test_conditions["parameters"][:, 1:]) < 1e-6).all()
+    assert (np.abs(fixed_samples[..., 0] - test_conditions["parameters"][:, :1]) > 0.1).any()  # should vary
+
+    infer_target_mask = keras.ops.concatenate(
+        (
+            keras.ops.ones(1),  # param 1 is inferred only
+            keras.ops.zeros(1),  # param 2 is marginalized
+        )
+    )
+    infer_target_mask = np.broadcast_to(infer_target_mask, (5, 2))
+    marginalized_samples = workflow.sample(
+        conditions=test_conditions,
+        num_samples=num_samples,
+        infer_target_mask=infer_target_mask,
+    )["parameters"]
+    assert samples.shape == marginalized_samples.shape
+
+
+def test_masking_unconditional(diffusion_type_inference_network):
+    _skip_torch_cpu_masking_workflow()
+
+    from bayesflow import BasicWorkflow
+    from bayesflow.simulators import TwoMoons
+
+    num_samples = 3
+    batch_size = 2
+    num_batches_per_epoch = 2
+    epochs = 5
+    workflow = BasicWorkflow(
+        inference_network=_build_network(diffusion_type_inference_network, epochs, num_batches_per_epoch),
+        inference_variables=["parameters"],
+        simulator=TwoMoons(),
+    )
+
+    workflow.fit_online(epochs=epochs, batch_size=batch_size, num_batches_per_epoch=num_batches_per_epoch)
+    test_conditions = workflow.simulate((5,))
+
+    test_conditions_adapted = workflow.adapter(test_conditions)
+    fixed_target_mask = keras.ops.concatenate(
+        (
+            keras.ops.ones(1),  # param 1 is inferred
+            keras.ops.zeros(1),  # param 2 is fixed
+        )
+    )
+    fixed_target_mask = np.broadcast_to(fixed_target_mask, (5, num_samples, 2)).reshape(-1, 2)
+    targets_fixed = test_conditions_adapted["inference_variables"]
+    targets_fixed = np.broadcast_to(np.expand_dims(targets_fixed, axis=1), (5, num_samples, 2)).reshape(-1, 2)
+
+    fixed_samples = workflow.sample(
+        num_samples=num_samples * 5, fixed_target_value=targets_fixed, fixed_target_mask=fixed_target_mask
+    )["parameters"].reshape(5, num_samples, 2)
+    assert (np.abs(fixed_samples[..., 1] - test_conditions["parameters"][:, 1:]) < 1e-6).all()
+    assert (np.abs(fixed_samples[..., 0] - test_conditions["parameters"][:, :1]) > 0.1).any()  # should vary


### PR DESCRIPTION
Trying to fix #739 with improved adaptive solvers for density computation. 

I tightened the default tolerances for density computations (in general multi-component states). Moreover, I centralized error normalization for computing adaptive step sizes, which is important if multiple states (`xz` and `trace` for density computation) are passed.